### PR TITLE
Some QOL changes to discpp::Snowflake

### DIFF
--- a/include/discpp/snowflake.h
+++ b/include/discpp/snowflake.h
@@ -4,6 +4,10 @@
 #include <string>
 
 namespace discpp {
+    enum class CommonTimeFormat : int {
+        CUSTOM, DEFAULT, ISO8601
+    };
+
     class Snowflake {
     private:
         uint64_t id;
@@ -13,6 +17,9 @@ namespace discpp {
         explicit Snowflake(const std::string& snowflake) noexcept : id(std::stoll(snowflake)) {}
         operator uint64_t() const { return id; }
         operator std::string() const { return std::to_string(id); }
+
+        std::string GetFormattedTimestamp(CommonTimeFormat format = CommonTimeFormat::DEFAULT, const std::string& format_str = "", bool localtime = false) const;
+        time_t GetRawTime() const;
     };
 }
 

--- a/include/discpp/snowflake.h
+++ b/include/discpp/snowflake.h
@@ -5,7 +5,7 @@
 
 namespace discpp {
     enum class CommonTimeFormat : int {
-        CUSTOM, DEFAULT, ISO8601
+        CUSTOM, DEFAULT, ISO8601, EUROPEAN, AMERICAN
     };
 
 

--- a/include/discpp/snowflake.h
+++ b/include/discpp/snowflake.h
@@ -8,8 +8,6 @@ namespace discpp {
         CUSTOM, DEFAULT, ISO8601, EUROPEAN, AMERICAN
     };
 
-
-
     class Snowflake {
     private:
         uint64_t id;

--- a/include/discpp/snowflake.h
+++ b/include/discpp/snowflake.h
@@ -8,6 +8,8 @@ namespace discpp {
         CUSTOM, DEFAULT, ISO8601
     };
 
+
+
     class Snowflake {
     private:
         uint64_t id;

--- a/src/guild.cpp
+++ b/src/guild.cpp
@@ -902,11 +902,11 @@ namespace discpp {
     }
 
     std::string Guild::GetFormattedCreatedAt() const {
-        return FormatTime(TimeFromSnowflake(id));
+        return id.GetFormattedTimestamp();
     }
 
     std::chrono::system_clock::time_point Guild::GetCreatedAt() const {
-        return std::chrono::system_clock::from_time_t(TimeFromSnowflake(id));
+        return std::chrono::system_clock::from_time_t(id.GetRawTime());
     }
 
     GuildInvite::GuildInvite(rapidjson::Document &json) {

--- a/src/snowflake.cpp
+++ b/src/snowflake.cpp
@@ -5,23 +5,19 @@
 namespace discpp {
 
     std::string Snowflake::GetFormattedTimestamp(CommonTimeFormat format, const std::string &format_str, bool localtime) const {
-        bool use_format_str = true;
         std::string time_format;
         switch (format) {
             case CommonTimeFormat::ISO8601:
-                use_format_str = false;
                 time_format = "%Y-%m-%dT%H:%M:%SZ";
                 break;
             case CommonTimeFormat::DEFAULT:
-                use_format_str = false;
                 time_format = "%F @ %r %Z";
                 break;
             default:
-                use_format_str = true;
                 time_format = format_str;
                 break;
         }
-        return discpp::FormatTime(this->GetRawTime(), format_str);
+        return discpp::FormatTime(this->GetRawTime(), time_format);
     }
 
     time_t Snowflake::GetRawTime() const {

--- a/src/snowflake.cpp
+++ b/src/snowflake.cpp
@@ -27,19 +27,12 @@ namespace discpp {
         time_t time = this->GetRawTime();
 
         struct tm now{};
-#ifndef __linux__
+
         if (localtime) {
             localtime_s(&now, &time);
         } else {
             gmtime_s(&now, &time);
         }
-#else
-        if (localtime) {
-            now = *localtime(&time);
-        } else {
-            now = *gmtime(&time);
-        }
-#endif
 
         char buffer[256];
         strftime(buffer, sizeof(buffer), time_format.c_str(), &now);

--- a/src/snowflake.cpp
+++ b/src/snowflake.cpp
@@ -1,0 +1,31 @@
+#include "discpp/snowflake.h"
+#include <stdlib.h>
+#include "discpp/utils.h"
+
+namespace discpp {
+
+    std::string Snowflake::GetFormattedTimestamp(CommonTimeFormat format, const std::string &format_str, bool localtime) const {
+        bool use_format_str = true;
+        std::string time_format;
+        switch (format) {
+            case CommonTimeFormat::ISO8601:
+                use_format_str = false;
+                time_format = "%Y-%m-%dT%H:%M:%SZ";
+                break;
+            case CommonTimeFormat::DEFAULT:
+                use_format_str = false;
+                time_format = "%F @ %r %Z";
+                break;
+            default:
+                use_format_str = true;
+                time_format = format_str;
+                break;
+        }
+        return discpp::FormatTime(this->GetRawTime(), format_str);
+    }
+
+    time_t Snowflake::GetRawTime() const {
+        constexpr static uint64_t discord_epoch = 1420070400000;
+        return ((this->id >> 22) + discord_epoch) / 1000;
+    }
+}

--- a/src/snowflake.cpp
+++ b/src/snowflake.cpp
@@ -10,6 +10,12 @@ namespace discpp {
             case CommonTimeFormat::ISO8601:
                 time_format = "%Y-%m-%dT%H:%M:%SZ";
                 break;
+            case CommonTimeFormat::AMERICAN:
+                time_format = "%m-%d-%Y %I:%M:%S %p";
+                break;
+            case CommonTimeFormat::EUROPEAN:
+                time_format = "%d-%m-%Y %H:%M:%S";
+                break;
             case CommonTimeFormat::DEFAULT:
                 time_format = (localtime ? "%F @ %r %Z" : "%F @ %r");
                 break;

--- a/src/user.cpp
+++ b/src/user.cpp
@@ -93,11 +93,11 @@ namespace discpp {
 	}
 
     std::string User::GetFormattedCreatedAt() const {
-        return FormatTime(TimeFromSnowflake(id));
+        return id.GetFormattedTimestamp();
     }
 
     std::chrono::system_clock::time_point User::GetCreatedAt() const {
-        return std::chrono::system_clock::from_time_t(TimeFromSnowflake(id));
+        return std::chrono::system_clock::from_time_t(id.GetRawTime());
 	}
 
     std::string User::CreateMention() {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -388,12 +388,7 @@ time_t discpp::TimeFromDiscord(const std::string &time) {
 
 std::string discpp::FormatTime(const time_t& time, const std::string& format) {
     struct tm now{};
-#ifndef __linux__
     localtime_s(&now, &time);
-#else
-    now = *localtime(&time);
-#endif
-
     char buffer[256];
     strftime(buffer, sizeof(buffer), format.c_str(), &now);
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -381,7 +381,7 @@ time_t discpp::TimeFromDiscord(const std::string &time) {
     return std::mktime(&tm);
 }
 
-time_t discpp::TimeFromSnowflake(const Snowflake& snow) {
+[[deprecated]] [[maybe_unused]] time_t discpp::TimeFromSnowflake(const Snowflake& snow) {
     constexpr static uint64_t discord_epoch = 1420070400000;
     return ((snow >> 22) + discord_epoch) / 1000;
 }


### PR DESCRIPTION
This moves some methods related to discpp::Snowflake out of places like utils.h and into it. Like `GetFormattedTimestamp` or `discpp::SnowflakeFromString`