### PR TITLE
Commands are now bound to a bot instance, updated cpr to latest

### DIFF
--- a/examples/pingbot/main.cpp
+++ b/examples/pingbot/main.cpp
@@ -29,7 +29,7 @@ int main(int argc, const char* argv[]) {
 
 	// I would recommend creating a class for the commands, you can check that in the examples folder
 	// But, you can still register a command like you did before
-	bot.command_handler->RegisterCommand("test", "Quick example of a quick command", [](discpp::Context ctx) {
+	bot.command_handler->RegisterCommand<discpp::Command>("test", "Quick example of a quick command", [](discpp::Context ctx) {
 		ctx.Send("Quick new command handler test");
 	});
 

--- a/examples/pingbot/main.cpp
+++ b/examples/pingbot/main.cpp
@@ -25,13 +25,13 @@ int main(int argc, const char* argv[]) {
 	discpp::ClientConfig* config = new discpp::ClientConfig({"!"});
 	discpp::Client bot{ token, config }; // Token, config
 
-	PingCommand(); // This runs the constructor which will register the command.
+	bot.command_handler->RegisterCommand<PingCommand>();
 
 	// I would recommend creating a class for the commands, you can check that in the examples folder
 	// But, you can still register a command like you did before
-	discpp::Command("test", "Quick example of a quick command", {}, [](discpp::Context ctx) {
+	bot.command_handler->RegisterCommand("test", "Quick example of a quick command", [](discpp::Context ctx) {
 		ctx.Send("Quick new command handler test");
-	}, {});
+	});
 
 	// New event system
     bot.event_handler->RegisterListener<discpp::ReadyEvent>([&] (const discpp::ReadyEvent& event) {

--- a/examples/serverinfo/main.cpp
+++ b/examples/serverinfo/main.cpp
@@ -20,7 +20,7 @@ int main(int argc, const char* argv[]) {
 	discpp::ClientConfig* config = new discpp::ClientConfig({"!"});
 	discpp::Client bot { token, config }; // Token, config
 
-	ServerinfoCommand();
+	bot.command_handler->RegisterCommand<ServerinfoCommand>();
 	
 	// ready event
     bot.event_handler->RegisterListener<discpp::ReadyEvent>([&] (const discpp::ReadyEvent& event) {

--- a/include/discpp/client.h
+++ b/include/discpp/client.h
@@ -78,6 +78,7 @@ namespace discpp {
 	};
 
 	class Shard;
+  class CommandHandler;
 
 	class Client {
 	    friend class Shard;
@@ -91,6 +92,7 @@ namespace discpp {
 		//std::unordered_map<Snowflake, std::shared_ptr<Channel>> channels; /**< List of channels the current bot can access. */
         discpp::Cache* cache; /**< Bot cache. Stores members, channels, guilds, etc. */
 		EventHandler* event_handler;
+		CommandHandler* command_handler;
 
         /**
          * @brief Constructs a discpp::Bot object.

--- a/include/discpp/client.h
+++ b/include/discpp/client.h
@@ -1,6 +1,7 @@
 #ifndef DISCPP_BOT_H
 #define DISCPP_BOT_H
 
+#include <memory>
 #include <string>
 #include <future>
 #include <string_view>
@@ -78,7 +79,7 @@ namespace discpp {
 	};
 
 	class Shard;
-  class CommandHandler;
+    class CommandHandler;
 
 	class Client {
 	    friend class Shard;
@@ -92,7 +93,7 @@ namespace discpp {
 		//std::unordered_map<Snowflake, std::shared_ptr<Channel>> channels; /**< List of channels the current bot can access. */
         discpp::Cache* cache; /**< Bot cache. Stores members, channels, guilds, etc. */
 		EventHandler* event_handler;
-		CommandHandler* command_handler;
+		std::shared_ptr<CommandHandler> command_handler;
 
         /**
          * @brief Constructs a discpp::Bot object.

--- a/include/discpp/command.h
+++ b/include/discpp/command.h
@@ -11,9 +11,9 @@ namespace discpp {
     class SubCommand;
 	class Command {
 	private:
-	    friend class SubCommand;
+	  friend class SubCommand;
       friend class CommandHandler;
-      CommandHandler* parent;
+      std::shared_ptr<CommandHandler> parent;
       
 	public:
 		Command() = default;

--- a/include/discpp/command.h
+++ b/include/discpp/command.h
@@ -12,6 +12,9 @@ namespace discpp {
 	class Command {
 	private:
 	    friend class SubCommand;
+      friend class CommandHandler;
+      CommandHandler* parent;
+      
 	public:
 		Command() = default;
 
@@ -35,7 +38,8 @@ namespace discpp {
          *
          * @return discpp::Command, this is a constructor.
          */
-		Command(const std::string& name, const std::string& desc, const std::vector<std::string>& hint_args, const std::function<void(discpp::Context)>& function, const std::vector<std::function<bool(discpp::Context)>>& requirements);
+		Command(const std::string& name, const std::string& desc, const std::vector<std::string>& hint_args, const std::function<void(discpp::Context)>& function, const std::vector<std::function<bool(discpp::Context)>>& requirements = {});
+		Command(const std::string& name, const std::string& desc, const std::function<void(discpp::Context)>& function, const std::vector<std::function<bool(discpp::Context)>>& requirements = {});
 
         /**
          * @brief The method that is executed when the command is triggered if overrided.
@@ -64,6 +68,7 @@ namespace discpp {
 		std::function<void(discpp::Context)> function = nullptr;
 		std::string name; /**< Name of the current command. Ex: "ping"*/
 		std::string description; /**< Description of the current command. Ex: "replies pong!" */
+		std::vector<std::string> aliases;
 		std::vector<std::string> hint_args; /**< Arguments of the current command. Ex: @user */
 		std::vector<std::function<bool(discpp::Context)>> requirements;
         std::unordered_map<std::string, discpp::SubCommand*> registered_commands;

--- a/include/discpp/command_handler.h
+++ b/include/discpp/command_handler.h
@@ -6,11 +6,31 @@
 #include "message.h"
 #include "command.h"
 
-#include <memory>
+#include <type_traits>
 
 namespace discpp {
-	inline std::unordered_map<std::string, Command*> registered_commands;
+    class CommandHandler {
+        Client &client;
+        friend class Client;
+        friend class Command;
+      public:
+        std::unordered_map<std::string, Command *> registered_commands;
 
+        CommandHandler(Client &parent) : client(parent) {}
+
+        template <typename T, typename... Args/*, std::enable_if_t<std::is_base_of<Command, T>::value || std::is_same<T, Command>::value> * = nullptr*/>
+        void RegisterCommand(Args &&... args)
+        {
+            auto command = new T(args...);
+            command->parent = this;
+
+            registered_commands.insert({command->name, command});
+            for (auto &alias : command->aliases)
+            {
+                registered_commands.insert({alias, command});
+            }
+        };
+    };
     /**
      * @brief Detects if a command has ran, and if it has then execute it.
      *

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -35,6 +35,8 @@ namespace discpp {
         this->my_instance_id = next_instance_id;
         next_instance_id++;
 
+        this->command_handler = new CommandHandler(*this);
+        
         client_instances.emplace(my_instance_id, this);
     }
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -16,6 +16,7 @@
 #include "cache.h"
 
 #include <ixwebsocket/IXNetSystem.h>
+#include <memory>
 
 namespace discpp {
     uint8_t Client::next_instance_id = 0;
@@ -35,7 +36,7 @@ namespace discpp {
         this->my_instance_id = next_instance_id;
         next_instance_id++;
 
-        this->command_handler = new CommandHandler(*this);
+        this->command_handler = std::make_shared<CommandHandler>(*this);
         
         client_instances.emplace(my_instance_id, this);
     }

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -1,9 +1,8 @@
+#include "log.h"
 #include "command.h"
 #include "command_handler.h"
 
-discpp::Command::Command(const std::string& name) : name(name) {
-	discpp::registered_commands.insert(std::make_pair(name, this));
-}
+discpp::Command::Command(const std::string& name) : name(name) { }
 
 discpp::Command::Command(const std::string& name, const std::string& desc, const std::vector<std::string>& hint_args, const std::function<void(discpp::Context)>& function, const std::vector<std::function<bool(discpp::Context)>>& requirements) : Command() {
 	this->name = name;
@@ -11,16 +10,20 @@ discpp::Command::Command(const std::string& name, const std::string& desc, const
 	this->hint_args = hint_args;
 	this->function = function;
 	this->requirements = requirements;
-
-	discpp::registered_commands.insert(std::make_pair(name, this));
+}
+discpp::Command::Command(const std::string& name, const std::string& desc, const std::function<void(discpp::Context)>& function, const std::vector<std::function<bool(discpp::Context)>>& requirements) : Command() {
+	this->name = name;
+	this->description = desc;
+	this->function = function;
+	this->requirements = requirements;
 }
 
 void discpp::Command::CommandBody(discpp::Context ctx) {
-	if (function == nullptr) {
-		std::cout << "Make sure to override the \"CommandBody(discpp::Context)\" method to get an actual command body for: \"" + name + "\"" << std::endl;
-	} else {
-		function(ctx);
-	}
+    if (function == nullptr) {
+        this->parent->client.logger->Info("CommandBody for command '" + this->name + "' is not set!");
+    } else {
+        function(ctx);
+    }
 }
 
 bool discpp::Command::CanRun(discpp::Context ctx) {
@@ -57,7 +60,7 @@ void discpp::Command::SubCommandHandler(discpp::Context ctx) {
 }
 
 void discpp::Command::AddAlias(const std::string& name) {
-    discpp::registered_commands.insert(std::make_pair(name, this));
+    this->aliases.push_back(name);
 }
 
 discpp::SubCommand::SubCommand(const std::string &name) {

--- a/src/command_handler.cpp
+++ b/src/command_handler.cpp
@@ -25,8 +25,8 @@ void discpp::FireCommand(discpp::Shard& shard, const discpp::Message& message) {
     std::vector<std::string> argument_vec = SplitString(messageContent, " ");
     if (!argument_vec.size()) return;
 
-    auto found_command = registered_commands.find(argument_vec[0]);
-    if (found_command == registered_commands.end()) return;
+    auto found_command = shard.client.command_handler->registered_commands.find(argument_vec[0]);
+    if (found_command == shard.client.command_handler->registered_commands.end()) return;
 
     argument_vec.erase(argument_vec.begin()); // Erase the command from the arguments
 


### PR DESCRIPTION
The CommandHandler is no longer global and is bound to a bot instance, so are the commands that are registered to it.
I changed the `std::cout` in the default `CommandBody` to use the `logger` instead.
I also updated cpr to the latest commit to fix some issues it had with 32bit which are fixed now.

I also updated the examples to work with the new CommandHandler.