### PR TITLE
Move the HTTPs methods into an abstract class

### DIFF
--- a/include/discpp/cache.h
+++ b/include/discpp/cache.h
@@ -20,10 +20,10 @@ namespace discpp {
         friend class EventDispatcher;
         friend class User;
     private:
-        std::unordered_map<discpp::Snowflake, std::shared_ptr<discpp::Member>> members;
-        std::unordered_map<discpp::Snowflake, std::shared_ptr<discpp::Guild>> guilds;
-        std::unordered_map<discpp::Snowflake, std::shared_ptr<discpp::Message>> messages;
-        std::unordered_map<discpp::Snowflake, discpp::Channel> private_channels;
+        std::unordered_map<discpp::Snowflake, std::shared_ptr<discpp::Member>, discpp::SnowflakeHash> members;
+        std::unordered_map<discpp::Snowflake, std::shared_ptr<discpp::Guild>, discpp::SnowflakeHash> guilds;
+        std::unordered_map<discpp::Snowflake, std::shared_ptr<discpp::Message>, discpp::SnowflakeHash> messages;
+        std::unordered_map<discpp::Snowflake, discpp::Channel, discpp::SnowflakeHash> private_channels;
 
         std::mutex members_mutex;
         std::mutex guilds_mutex;
@@ -36,33 +36,33 @@ namespace discpp {
          * @brief Get all members the bot is handling. Do not modify contents since it will break thread-safety!
          * If you just want to get a member, use discpp::Cache::GetMember().
          *
-         * @return const std::unordered_map<discpp::Snowflake, std::shared_ptr<discpp::Member>>
+         * @return const std::unordered_map<discpp::Snowflake, std::shared_ptr<discpp::Member>, discpp::SnowflakeHash>
          */
-        const std::unordered_map<discpp::Snowflake, std::shared_ptr<discpp::Member>> GetMembers();
+        const std::unordered_map<discpp::Snowflake, std::shared_ptr<discpp::Member>, discpp::SnowflakeHash> GetMembers();
 
         /**
          * @brief Get all guilds the bot is in. Do not modify contents since it will break thread-safety!
          * If you just want to get a guild, use discpp::Cache::GetGuild().
          *
-         * @return const std::unordered_map<discpp::Snowflake, std::shared_ptr<discpp::Guild>>
+         * @return const std::unordered_map<discpp::Snowflake, std::shared_ptr<discpp::Guild>, discpp::SnowflakeHash>
          */
-        const std::unordered_map<discpp::Snowflake, std::shared_ptr<discpp::Guild>> GetGuilds();
+        const std::unordered_map<discpp::Snowflake, std::shared_ptr<discpp::Guild>, discpp::SnowflakeHash> GetGuilds();
 
         /**
          * @brief Get all messages the bot has seen or requested. Do not modify contents since it will break thread-safety!
          * If you just want to get a message, use discpp::Cache::GetMessage().
          *
-         * @return const std::unordered_map<discpp::Snowflake, std::shared_ptr<discpp::Message>>
+         * @return const std::unordered_map<discpp::Snowflake, std::shared_ptr<discpp::Message>, discpp::SnowflakeHash>
          */
-        const std::unordered_map<discpp::Snowflake, std::shared_ptr<discpp::Message>> GetMessages();
+        const std::unordered_map<discpp::Snowflake, std::shared_ptr<discpp::Message>, discpp::SnowflakeHash> GetMessages();
 
         /**
          * @brief Get all private channels the bot is handling. Do not modify contents since it will break thread-safety!
          * If you just want to get a private channel, use discpp::Cache::GetPrivateChannel().
          *
-         * @return const std::unordered_map<discpp::Snowflake, discpp::Channel>
+         * @return const std::unordered_map<discpp::Snowflake, discpp::Channel, discpp::SnowflakeHash>
          */
-        const std::unordered_map<discpp::Snowflake, discpp::Channel> GetPrivateChannels();
+        const std::unordered_map<discpp::Snowflake, discpp::Channel, discpp::SnowflakeHash> GetPrivateChannels();
 
         /**
          * @brief Cache a discpp::Member.

--- a/include/discpp/channel.h
+++ b/include/discpp/channel.h
@@ -317,9 +317,9 @@ namespace discpp {
          *      auto children = category.GetChildren();
          * ```
          *
-         * @return std::unordered_map<discpp::Snowflake, discpp::Channel>
+         * @return std::unordered_map<discpp::Snowflake, discpp::Channel, discpp::SnowflakeHash>
          */
-        std::unordered_map<discpp::Snowflake, discpp::Channel> GetChildren();
+        std::unordered_map<discpp::Snowflake, discpp::Channel, discpp::SnowflakeHash> GetChildren();
 
         /**
         * @brief Add a recipient to the group dm.

--- a/include/discpp/client.h
+++ b/include/discpp/client.h
@@ -24,6 +24,7 @@ namespace discpp {
 	class Image;
 	class EventHandler;
 	class Cache;
+	class HttpClient;
 
 	class ClientUser : public User {
 	public:
@@ -89,6 +90,7 @@ namespace discpp {
 
         discpp::ClientUser client_user; /**< discpp::User object representing current user. */
         std::unique_ptr<discpp::Logger> logger; /**< discpp::Logger object representing current logger. */
+        std::shared_ptr<discpp::HttpClient> http_client; /**< Abstract http client. */
 
         std::unique_ptr<discpp::Cache> cache; /**< Bot cache. Stores members, channels, guilds, etc. */
 
@@ -110,7 +112,7 @@ namespace discpp {
          *
          * @return discpp::Bot, this is a constructor.
          */
-		Client(const std::string& token, ClientConfig& config);
+		Client(const std::string& token, std::shared_ptr<discpp::HttpClient> http_client, ClientConfig& config);
 
 		~Client();
 
@@ -167,9 +169,9 @@ namespace discpp {
         /**
          * @brief Get all friends. Only supports user tokens!
          *
-         * @return std::unordered_map<discpp::Snowflake, discpp::UserRelationship>
+         * @return std::unordered_map<discpp::Snowflake, discpp::UserRelationship, discpp::SnowflakeHash>
          */
-        std::unordered_map<discpp::Snowflake, discpp::UserRelationship> GetRelationships();
+        std::unordered_map<discpp::Snowflake, discpp::UserRelationship, discpp::SnowflakeHash> GetRelationships();
 
         /**
          * @brief Modify the client's user.
@@ -225,9 +227,9 @@ namespace discpp {
         /**
          * @brief Get all DM's for this user. Only supports user tokens!
          *
-         * @return std::vector<discpp::User::Connection>
+         * @return std::unordered_map<discpp::Snowflake, discpp::Channel, discpp::SnowflakeHash>
          */
-        std::unordered_map<discpp::Snowflake, discpp::Channel> GetUserDMs();
+        std::unordered_map<discpp::Snowflake, discpp::Channel, discpp::SnowflakeHash> GetUserDMs();
 
         // discpp::Channel CreateGroupDM(std::vector<discpp::User> users); // Deprecated and will not be shown in the discord client.
 

--- a/include/discpp/discord_object.h
+++ b/include/discpp/discord_object.h
@@ -18,12 +18,12 @@ namespace discpp {
 
 		discpp::Snowflake id = 0;
 
-		bool operator==(DiscordObject& other) const;
-		bool operator==(discpp::Snowflake& other) const;
+		bool operator==(const DiscordObject& other) const;
+		bool operator==(const discpp::Snowflake& other) const;
 
 #if __cplusplus <= 201703L || defined(__GNUC__)
-		bool operator!=(DiscordObject& other) const;
-		bool operator!=(discpp::Snowflake& other) const;
+		bool operator!=(const DiscordObject& other) const;
+		bool operator!=(const discpp::Snowflake& other) const;
 #endif
 	private:
 	    uint8_t client_instance_id;

--- a/include/discpp/emoji.h
+++ b/include/discpp/emoji.h
@@ -2,6 +2,7 @@
 #define DISCPP_EMOJI_H
 
 #ifdef WIN32
+#define NOMINMAX
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #undef WIN32_LEAN_AND_MEAN

--- a/include/discpp/emoji.h
+++ b/include/discpp/emoji.h
@@ -133,11 +133,11 @@ namespace discpp {
             }
 #endif
 
-            if (other.id != 0 && id != 0 && !other.name.empty() && !name.empty()) {
+            if (other.id.IsValid() && id.IsValid() && !other.name.empty() && !name.empty()) {
                 return other.id == id && other.name == name;
             } else if (!other.name.empty() && !name.empty()) {
                 return other.name == name;
-            } else if (other.id != 0 && id != 0) {
+            } else if (other.id.IsValid() && id.IsValid()) {
                 return other.id == id;
             }
 
@@ -154,7 +154,7 @@ namespace discpp {
          * @return std::string
          */
         std::string ToString() {
-            if (name.empty() && id == 0) {
+            if (name.empty() && !id.IsValid()) {
 #ifdef WIN32
                 char ansi_emoji[MAX_PATH];
                 if (!WideCharToMultiByte(CP_UTF8, WC_COMPOSITECHECK, unicode.c_str(), -1, ansi_emoji, MAX_PATH, nullptr, nullptr)) {
@@ -187,7 +187,7 @@ namespace discpp {
 			if (name.empty()) {
 				emoji = unicode;
 			} else {
-                return URIEncode(name + ":" + std::to_string(id));
+                return URIEncode(name + ":" + (std::string) id);
 			}
 #ifdef WIN32
 			char ansi_emoji[MAX_PATH];

--- a/include/discpp/events/guild_members_chunk_event.h
+++ b/include/discpp/events/guild_members_chunk_event.h
@@ -9,10 +9,10 @@ namespace discpp {
 	class GuildMembersChunkEvent : public Event {
 	public:
 	    GuildMembersChunkEvent() = default;
-        GuildMembersChunkEvent(Shard& shard, std::shared_ptr<discpp::Guild> guild, std::unordered_map<discpp::Snowflake, discpp::Member> members, int chunk_index, int chunk_count, std::vector<discpp::Presence> presences, std::string nonce) : Event(shard), guild(std::move(guild)), members(std::move(members)), chunk_index(chunk_index), chunk_count(chunk_count), presences(std::move(presences)), nonce(std::move(nonce)) {};
+        GuildMembersChunkEvent(Shard& shard, std::shared_ptr<discpp::Guild> guild, std::unordered_map<discpp::Snowflake, discpp::Member, discpp::SnowflakeHash> members, int chunk_index, int chunk_count, std::vector<discpp::Presence> presences, std::string nonce) : Event(shard), guild(std::move(guild)), members(std::move(members)), chunk_index(chunk_index), chunk_count(chunk_count), presences(std::move(presences)), nonce(std::move(nonce)) {};
 
         std::shared_ptr<discpp::Guild> guild;
-		std::unordered_map<discpp::Snowflake, discpp::Member> members;
+		std::unordered_map<discpp::Snowflake, discpp::Member, discpp::SnowflakeHash> members;
 		int chunk_index;
 		int chunk_count;
 		std::vector<discpp::Presence> presences;

--- a/include/discpp/guild.h
+++ b/include/discpp/guild.h
@@ -273,12 +273,12 @@ namespace discpp {
          * This will send a REST request to receive, and update the guild's channel list.
          *
          * ```cpp
-         *      std::unordered_map<discpp::Snowflake, discpp::Channel> guild.UpdateChannels();
+         *      std::unordered_map<discpp::Snowflake, discpp::Channel, discpp::SnowflakeHash> guild.UpdateChannels();
          * ```
          *
-         * @return std::unordered_map<discpp::Snowflake, discpp::Channel>
+         * @return std::unordered_map<discpp::Snowflake, discpp::Channel, discpp::SnowflakeHash>
          */
-		std::unordered_map<discpp::Snowflake, discpp::Channel> UpdateChannels();
+		std::unordered_map<discpp::Snowflake, discpp::Channel, discpp::SnowflakeHash> UpdateChannels();
 
         /**
          * @brief Gets a list of channel categories in this guild.
@@ -287,12 +287,12 @@ namespace discpp {
          * This makes it easy to find a channel in the array by using the `std::unordered_map::find()` method.
          *
          * ```cpp
-         *      std::unordered_map<discpp::Snowflake, discpp::Channel> guild.GetCategories();
+         *      std::unordered_map<discpp::Snowflake, discpp::Channel, discpp::SnowflakeHash> guild.GetCategories();
          * ```
          *
-         * @return std::unordered_map<discpp::Snowflake, discpp::Channel>
+         * @return std::unordered_map<discpp::Snowflake, discpp::Channel, discpp::SnowflakeHash>
          */
-		std::unordered_map<discpp::Snowflake, discpp::Channel> GetCategories();
+		std::unordered_map<discpp::Snowflake, discpp::Channel, discpp::SnowflakeHash> GetCategories();
 
         /**
          * @brief Gets a list of channel that don't have parents in this guild.
@@ -300,9 +300,9 @@ namespace discpp {
          * The first element in the map is the id of the channel, while the second is the channel object.
          * This makes it easy to find a channel in the array by using the `std::unordered_map::find()` method.
          *
-         * @return std::unordered_map<discpp::Snowflake, discpp::Channel>
+         * @return std::unordered_map<discpp::Snowflake, discpp::Channel, discpp::SnowflakeHash>
          */
-        std::unordered_map<Snowflake, Channel> GetParentlessChannels();
+        std::unordered_map<Snowflake, Channel, discpp::SnowflakeHash> GetParentlessChannels();
 
         /**
          * @brief Gets a channel in this guild.
@@ -756,12 +756,12 @@ namespace discpp {
          * Only do this if, for some reason, the emojis have gotten out of sync!
          *
          * ```cpp
-         *      std::unordered_map<Snowflake, std::shared_ptr<Emoji>> guild_emojis = guild.GetEmojis();
+         *      std::unordered_map<Snowflake, std::shared_ptr<Emoji>, discpp::SnowflakeHash> guild_emojis = guild.GetEmojis();
          * ```
          *
-         * @return std::unordered_map<Snowflake, std::shared_ptr<Emoji>>
+         * @return std::unordered_map<Snowflake, std::shared_ptr<Emoji>, discpp::SnowflakeHash>
          */
-		std::unordered_map<Snowflake, discpp::Emoji> UpdateEmojis();
+        std::unordered_map<Snowflake, discpp::Emoji, discpp::SnowflakeHash> UpdateEmojis();
 
         /**
          * @brief Get a guild emoji.
@@ -981,36 +981,36 @@ namespace discpp {
         /**
          * @brief Get a constant map of roles.
          *
-         * @return std::unordered_map<Snowflake, std::shared_ptr<Role>>
+         * @return std::unordered_map<Snowflake, std::shared_ptr<Role>, discpp::SnowflakeHash>
          */
-        inline std::unordered_map<Snowflake, std::shared_ptr<Role>> GetRoles() const {
+        inline std::unordered_map<Snowflake, std::shared_ptr<Role>, discpp::SnowflakeHash> GetRoles() const {
             return roles;
         }
 
         /**
          * @brief Get a constant map of members.
          *
-         * @return std::unordered_map<Snowflake, std::shared_ptr<Member>>
+         * @return std::unordered_map<Snowflake, std::shared_ptr<Member>, discpp::SnowflakeHash>
          */
-        inline std::unordered_map<Snowflake, std::shared_ptr<Member>> GetMembers() const {
+        inline std::unordered_map<Snowflake, std::shared_ptr<Member>, discpp::SnowflakeHash> GetMembers() const {
             return members;
         }
 
         /**
          * @brief Get a constant map of channels.
          *
-         * @return std::unordered_map<Snowflake, Channel>
+         * @return std::unordered_map<Snowflake, Channel, discpp::SnowflakeHash>
          */
-        inline std::unordered_map<Snowflake, Channel> GetChannels() const {
+        inline std::unordered_map<Snowflake, Channel, discpp::SnowflakeHash> GetChannels() const {
             return channels;
         }
 
         /**
          * @brief Get a constant map of emojis.
          *
-         * @return std::unordered_map<Snowflake, Emoji>
+         * @return std::unordered_map<Snowflake, Emoji, discpp::SnowflakeHash>
          */
-        inline std::unordered_map<Snowflake, Emoji> GetEmojis() const {
+        inline std::unordered_map<Snowflake, Emoji, discpp::SnowflakeHash> GetEmojis() const {
             return emojis;
         }
 
@@ -1054,10 +1054,10 @@ namespace discpp {
 	    std::mutex members_mutex;
 	    std::mutex channels_mutex;
 
-        std::unordered_map<Snowflake, std::shared_ptr<Role>> roles;
-        std::unordered_map<Snowflake, Emoji> emojis;
-        std::unordered_map<Snowflake, std::shared_ptr<Member>> members;
-        std::unordered_map<Snowflake, discpp::Channel> channels;
+        std::unordered_map<Snowflake, std::shared_ptr<Role>, discpp::SnowflakeHash> roles;
+        std::unordered_map<Snowflake, Emoji, discpp::SnowflakeHash> emojis;
+        std::unordered_map<Snowflake, std::shared_ptr<Member>, discpp::SnowflakeHash> members;
+        std::unordered_map<Snowflake, discpp::Channel, discpp::SnowflakeHash> channels;
 
         unsigned char flags = 0b0;
         uint64_t icon_hex[2] = {0, 0};

--- a/include/discpp/guild.h
+++ b/include/discpp/guild.h
@@ -981,36 +981,36 @@ namespace discpp {
         /**
          * @brief Get a constant map of roles.
          *
-         * @return std::unordered_map<Snowflake, std::shared_ptr<Role>, discpp::SnowflakeHash>
+         * @return const std::unordered_map<Snowflake, std::shared_ptr<Role>, discpp::SnowflakeHash>&
          */
-        inline std::unordered_map<Snowflake, std::shared_ptr<Role>, discpp::SnowflakeHash> GetRoles() const {
+        inline const std::unordered_map<Snowflake, std::shared_ptr<Role>, discpp::SnowflakeHash>& GetRoles() const {
             return roles;
         }
 
         /**
          * @brief Get a constant map of members.
          *
-         * @return std::unordered_map<Snowflake, std::shared_ptr<Member>, discpp::SnowflakeHash>
+         * @return const std::unordered_map<Snowflake, std::shared_ptr<Member>, discpp::SnowflakeHash>&
          */
-        inline std::unordered_map<Snowflake, std::shared_ptr<Member>, discpp::SnowflakeHash> GetMembers() const {
+        inline const std::unordered_map<Snowflake, std::shared_ptr<Member>, discpp::SnowflakeHash>& GetMembers() const {
             return members;
         }
 
         /**
          * @brief Get a constant map of channels.
          *
-         * @return std::unordered_map<Snowflake, Channel, discpp::SnowflakeHash>
+         * @return const std::unordered_map<Snowflake, Channel, discpp::SnowflakeHash>&
          */
-        inline std::unordered_map<Snowflake, Channel, discpp::SnowflakeHash> GetChannels() const {
+        inline const std::unordered_map<Snowflake, Channel, discpp::SnowflakeHash>& GetChannels() const {
             return channels;
         }
 
         /**
          * @brief Get a constant map of emojis.
          *
-         * @return std::unordered_map<Snowflake, Emoji, discpp::SnowflakeHash>
+         * @return const std::unordered_map<Snowflake, Emoji, discpp::SnowflakeHash>&
          */
-        inline std::unordered_map<Snowflake, Emoji, discpp::SnowflakeHash> GetEmojis() const {
+        inline const std::unordered_map<Snowflake, Emoji, discpp::SnowflakeHash>& GetEmojis() const {
             return emojis;
         }
 

--- a/include/discpp/http_client.h
+++ b/include/discpp/http_client.h
@@ -1,0 +1,122 @@
+#ifndef DISCPP_HTTP_CLIENT_H
+#define DISCPP_HTTP_CLIENT_H
+
+#include <memory>
+#include <string>
+#include <map>
+
+#include "snowflake.h"
+#include "utils.h"
+
+#ifndef RAPIDJSON_HAS_STDSTRING
+#define RAPIDJSON_HAS_STDSTRING 1
+#endif
+
+#include <rapidjson/document.h>
+
+namespace discpp {
+    class Client;
+
+    class HttpClient {
+    protected:
+        discpp::Client* client;
+    public:
+        HttpClient() {
+
+        }
+
+        explicit HttpClient(discpp::Client* client) : client(client) {
+
+        }
+
+        void SetClient(discpp::Client* client) {
+            this->client = client;
+        }
+
+        /**
+         * @brief Sends a get request to a url.
+         *
+         * @param[in] url The url to create a request to.
+         * @param[in] headers The http header.
+         * @param[in] object The object id to handle the ratelimits for.
+         * @param[in] ratelimit_bucket The rate limit bucket.
+         * @param[in] body The body of the request.
+         *
+         * @return std::unique_ptr<rapidjson::Document>
+         */
+        virtual std::unique_ptr<rapidjson::Document> SendGetRequest(std::string url, std::map<std::string, std::string, discpp::CaseInsensitiveLess> headers, discpp::Snowflake object, discpp::RateLimitBucketType ratelimit_bucket, std::string body = {}) = 0;
+
+        /**
+         * @brief Sends a post request to a url.
+         *
+         * @param[in] url The url to create a request to.
+         * @param[in] headers The http header.
+         * @param[in] object The object id to handle the ratelimits for.
+         * @param[in] ratelimit_bucket The rate limit bucket.
+         * @param[in] body The body of the request.
+         *
+         * @return std::unique_ptr<rapidjson::Document>
+         */
+        virtual std::unique_ptr<rapidjson::Document> SendPostRequest(std::string url, std::map<std::string, std::string, discpp::CaseInsensitiveLess> headers, discpp::Snowflake object, discpp::RateLimitBucketType ratelimit_bucket, std::string body = {}) = 0;
+
+        /**
+         * @brief Sends a put request to a url.
+         *
+         * @param[in] url The url to create a request to.
+         * @param[in] headers The http header.
+         * @param[in] object The object id to handle the ratelimits for.
+         * @param[in] ratelimit_bucket The rate limit bucket.
+         * @param[in] body The body of the request.
+         *
+         * @return std::unique_ptr<rapidjson::Document>
+         */
+        virtual std::unique_ptr<rapidjson::Document> SendPutRequest(std::string url, std::map<std::string, std::string, discpp::CaseInsensitiveLess> headers, discpp::Snowflake object, discpp::RateLimitBucketType ratelimit_bucket, std::string body = {}) = 0;
+
+        /**
+         * @brief Sends a patch request to a url.
+         *
+         * @param[in] url The url to create a request to.
+         * @param[in] headers The http header.
+         * @param[in] object The object id to handle the ratelimits for.
+         * @param[in] ratelimit_bucket The rate limit bucket.
+         * @param[in] body The body of the request.
+         *
+         * @return std::unique_ptr<rapidjson::Document>
+         */
+        virtual std::unique_ptr<rapidjson::Document> SendPatchRequest(std::string url, std::map<std::string, std::string, discpp::CaseInsensitiveLess> headers, discpp::Snowflake object, discpp::RateLimitBucketType ratelimit_bucket, std::string body = {}) = 0;
+
+        /**
+         * @brief Sends a delete request to a url.
+         *
+         * @param[in] url The url to create a request to.
+         * @param[in] headers The http header.
+         * @param[in] object The object id to handle the ratelimits for.
+         * @param[in] ratelimit_bucket The rate limit bucket.
+         *
+         * @return std::unique_ptr<rapidjson::Document>
+         */
+        virtual std::unique_ptr<rapidjson::Document> SendDeleteRequest(std::string url, std::map<std::string, std::string, discpp::CaseInsensitiveLess> headers, discpp::Snowflake object, discpp::RateLimitBucketType ratelimit_bucket) = 0;
+
+        /**
+         * @brief Gets the default headers to communicate with discord.
+         *
+         * @param[in] add The headers to add to the default ones.
+         *
+         * @return std::map<std::string, std::string>
+         */
+        virtual std::map<std::string, std::string, discpp::CaseInsensitiveLess> DefaultHeaders(std::map<std::string, std::string, CaseInsensitiveLess> add = {});
+
+        /**
+         * @brief Handles a response from the discpp servers.
+         *
+         * @param[in] reponse The cpr response from the servers.
+         * @param[in] object The object id to handle the ratelimits for.
+         * @param[in] ratelimit_bucket The rate limit bucket.
+         *
+         * @return std::unique_ptr<rapidjson::Document>
+         */
+        virtual std::unique_ptr<rapidjson::Document> HandleResponse(std::string response_body, int status_code, const std::map<std::string, std::string, CaseInsensitiveLess> &headers, discpp::RateLimitBucketType ratelimit_bucket, discpp::Snowflake object);
+    };
+}
+
+#endif //DISCPP_HTTP_CLIENT_H

--- a/include/discpp/ixweb_http_client.h
+++ b/include/discpp/ixweb_http_client.h
@@ -1,0 +1,27 @@
+//
+// Created by sean_ on 12/21/2020.
+//
+
+#ifndef DISCPP_IXWEBHTTPCLIENT_H
+#define DISCPP_IXWEBHTTPCLIENT_H
+
+#include "http_client.h"
+
+namespace discpp {
+    class IXWebHttpClient : public discpp::HttpClient {
+    public:
+        IXWebHttpClient() = default;
+
+        explicit IXWebHttpClient(discpp::Client* client) : discpp::HttpClient(client) {
+
+        }
+
+        std::unique_ptr<rapidjson::Document> SendGetRequest(std::string url, std::map<std::string, std::string, discpp::CaseInsensitiveLess> headers, discpp::Snowflake object, RateLimitBucketType ratelimit_bucket, std::string body = {}) override;
+        std::unique_ptr<rapidjson::Document> SendPostRequest(std::string url, std::map<std::string, std::string, discpp::CaseInsensitiveLess> headers, discpp::Snowflake object, RateLimitBucketType ratelimit_bucket, std::string body = {}) override;
+        std::unique_ptr<rapidjson::Document> SendPutRequest(std::string url, std::map<std::string, std::string, discpp::CaseInsensitiveLess> headers, discpp::Snowflake object, RateLimitBucketType ratelimit_bucket, std::string body = {}) override;
+        std::unique_ptr<rapidjson::Document> SendPatchRequest(std::string url, std::map<std::string, std::string, discpp::CaseInsensitiveLess> headers, discpp::Snowflake object, RateLimitBucketType ratelimit_bucket, std::string body = {}) override;
+        std::unique_ptr<rapidjson::Document> SendDeleteRequest(std::string url, std::map<std::string, std::string, discpp::CaseInsensitiveLess> headers, discpp::Snowflake object, RateLimitBucketType ratelimit_bucket) override;
+    };
+}
+
+#endif //DISCPP_IXWEBHTTPCLIENT_H

--- a/include/discpp/member.h
+++ b/include/discpp/member.h
@@ -229,9 +229,9 @@ namespace discpp {
         /**
          * @brief Returns member roles as objects instead of the snowflake vector.
          *
-         * @return std::vector<std::shared_ptr<discpp::Role>>
+         * @return std::vector<std::shared_ptr<discpp::Role>, discpp::SnowflakeHash>
          */
-        std::unordered_map<discpp::Snowflake, std::shared_ptr<discpp::Role>> GetRoles();
+        std::unordered_map<discpp::Snowflake, std::shared_ptr<discpp::Role>, discpp::SnowflakeHash> GetRoles();
 
         /**
          * @brief Returns member roles but ordered by position.

--- a/include/discpp/message.h
+++ b/include/discpp/message.h
@@ -159,15 +159,15 @@ namespace discpp {
          * You can use `std::unordered_map::find` to check if a user is contained in it with the users id.
          *
          * ```cpp
-         *      std::unordered_map<discpp::Snowflake, discpp::User> reactors = message.GetReactorOfEmoji(emoji, 50);
+         *      std::unordered_map<discpp::Snowflake, discpp::User, discpp::SnowflakeHash> reactors = message.GetReactorOfEmoji(emoji, 50);
          * ```
          *
          * @param[in] emoji The emoji to get reactors of.
          * @param[in] amount The amount of users to get.
          *
-         * @return std::vector<discpp::User>
+         * @return std::unordered_map<discpp::Snowflake, discpp::User, discpp::SnowflakeHash>
          */
-        std::unordered_map<discpp::Snowflake, discpp::User> GetReactorsOfEmoji(const discpp::Emoji& emoji, const int& amount);
+        std::unordered_map<discpp::Snowflake, discpp::User, discpp::SnowflakeHash> GetReactorsOfEmoji(const discpp::Emoji& emoji, const int& amount);
 
         /**
          * @brief Get reactors of a specific emoji of the specific method.
@@ -175,16 +175,16 @@ namespace discpp {
          * You can use `std::unordered_map::find` to check if a user is contained in it with the users id.
          *
          * ```cpp
-         *      std::unordered_map<discpp::Snowflake, discpp::User> reactors = message.GetReactorOfEmoji(emoji, 50, reaction_method);
+         *      std::unordered_map<discpp::Snowflake, discpp::User, discpp::SnowflakeHash> reactors = message.GetReactorOfEmoji(emoji, 50, reaction_method);
          * ```
          *
          * @param[in] emoji The emoji to get reactors of.
          * @param[in] amount The amount of users to get.
          * @param[in] method The method the users reacted by.
          *
-         * @return std::vector<discpp::User>
+         * @return std::unordered_map<discpp::Snowflake, discpp::User, discpp::SnowflakeHash>
          */
-		std::unordered_map<discpp::Snowflake, discpp::User> GetReactorsOfEmoji(const discpp::Emoji& emoji, const discpp::User& user, const GetReactionsMethod& method);
+		std::unordered_map<discpp::Snowflake, discpp::User, discpp::SnowflakeHash> GetReactorsOfEmoji(const discpp::Emoji& emoji, const discpp::User& user, const GetReactionsMethod& method);
 
         /**
          * @brief Clear message reactions.
@@ -329,9 +329,9 @@ namespace discpp {
 		std::string content;
 		std::chrono::system_clock::time_point timestamp;
 		std::chrono::system_clock::time_point edited_timestamp = std::chrono::system_clock::from_time_t(0);
-		std::unordered_map<discpp::Snowflake, discpp::User> mentions;
+		std::unordered_map<discpp::Snowflake, discpp::User, discpp::SnowflakeHash> mentions;
 		std::vector<discpp::Snowflake> mentioned_roles;
-        std::unordered_map<discpp::Snowflake, ChannelMention> mention_channels;
+        std::unordered_map<discpp::Snowflake, ChannelMention, discpp::SnowflakeHash> mention_channels;
 		std::vector<discpp::Attachment> attachments;
 		std::vector<discpp::EmbedBuilder> embeds;
 		std::vector<discpp::Reaction> reactions;

--- a/include/discpp/snowflake.h
+++ b/include/discpp/snowflake.h
@@ -17,36 +17,65 @@ namespace discpp {
         Snowflake(const uint64_t& snowflake) : id(snowflake) {}
         explicit Snowflake(const std::string& snowflake) : id(std::stoll(snowflake)) {}
 
-        operator uint64_t() const { return id; }
+        explicit operator uint64_t() const { return id; }
         explicit operator std::string() const { return std::to_string(id); }
 
         std::string GetFormattedTimestamp(CommonTimeFormat format = CommonTimeFormat::DEFAULT, const std::string& format_str = "", bool localtime_format = false) const;
         time_t GetRawTime() const;
 
+        bool IsValid() const {
+            return id != (uint64_t) 0;
+        }
+
         // These operators are defined to make sure that the class isn't casted to uint64 before being checked with the operator.
         // We could probably define more, but these are the ones that would probably be used the most.
-        bool operator==(const Snowflake& other) {
+        bool operator==(const Snowflake& other) const {
             return other.id == this->id;
         }
 
-        bool operator!=(const Snowflake& other) {
+        bool operator!=(const Snowflake& other) const {
             return other.id != this->id;
         }
 
-        bool operator>(const Snowflake& other) {
+        bool operator>(const Snowflake& other) const {
             return other.id > this->id;
         }
 
-        bool operator<(const Snowflake& other) {
+        bool operator<(const Snowflake& other) const {
             return other.id < this->id;
         }
 
-        bool operator>=(const Snowflake& other) {
+        bool operator>=(const Snowflake& other) const {
             return other.id >= this->id;
         }
 
-        bool operator<=(const Snowflake& other) {
+        bool operator<=(const Snowflake& other) const {
             return other.id <= this->id;
+        }
+
+        // Operators for comparing snowflake and uint64_t.
+        bool operator==(const uint64_t& other) const {
+            return other == this->id;
+        }
+
+        bool operator!=(const uint64_t& other) const {
+            return other != this->id;
+        }
+
+        bool operator>(const uint64_t& other) const {
+            return other > this->id;
+        }
+
+        bool operator<(const uint64_t& other) const {
+            return other < this->id;
+        }
+
+        bool operator>=(const uint64_t& other) const {
+            return other >= this->id;
+        }
+
+        bool operator<=(const uint64_t& other) const {
+            return other <= this->id;
         }
     };
 

--- a/include/discpp/snowflake.h
+++ b/include/discpp/snowflake.h
@@ -9,6 +9,7 @@ namespace discpp {
     };
 
     class Snowflake {
+        friend struct SnowflakeHash;
     private:
         uint64_t id;
     public:
@@ -17,18 +18,41 @@ namespace discpp {
         explicit Snowflake(const std::string& snowflake) : id(std::stoll(snowflake)) {}
 
         operator uint64_t() const { return id; }
-        operator std::string() const { return std::to_string(id); }
+        explicit operator std::string() const { return std::to_string(id); }
 
         std::string GetFormattedTimestamp(CommonTimeFormat format = CommonTimeFormat::DEFAULT, const std::string& format_str = "", bool localtime_format = false) const;
         time_t GetRawTime() const;
-    };
-}
 
-namespace std {
-    template<>
-    struct hash<discpp::Snowflake> {
-        std::size_t operator()(const discpp::Snowflake& snowflake) const {
-          return std::hash<uint64_t>()((uint64_t) snowflake);
+        // These operators are defined to make sure that the class isn't casted to uint64 before being checked with the operator.
+        // We could probably define more, but these are the ones that would probably be used the most.
+        bool operator==(const Snowflake& other) {
+            return other.id == this->id;
+        }
+
+        bool operator!=(const Snowflake& other) {
+            return other.id != this->id;
+        }
+
+        bool operator>(const Snowflake& other) {
+            return other.id > this->id;
+        }
+
+        bool operator<(const Snowflake& other) {
+            return other.id < this->id;
+        }
+
+        bool operator>=(const Snowflake& other) {
+            return other.id >= this->id;
+        }
+
+        bool operator<=(const Snowflake& other) {
+            return other.id <= this->id;
+        }
+    };
+
+    struct SnowflakeHash {
+        std::size_t operator()(const Snowflake& s) const noexcept {
+            return std::hash<uint64_t>{}(s.id);
         }
     };
 }

--- a/include/discpp/user.h
+++ b/include/discpp/user.h
@@ -119,9 +119,9 @@ namespace discpp {
         /**
          * @brief Returns mutual guilds
          *
-         * @return std::unordered_map<discpp::Snowflake, std::shared_ptr<discpp::Guild>>
+         * @return std::unordered_map<discpp::Snowflake, std::shared_ptr<discpp::Guild>, discpp::SnowflakeHash>
          */
-        std::unordered_map<discpp::Snowflake, std::shared_ptr<discpp::Guild>> GetMutualGuilds();
+        std::unordered_map<discpp::Snowflake, std::shared_ptr<discpp::Guild>, discpp::SnowflakeHash> GetMutualGuilds();
 
         /**
          * @brief Gets the created at time and date for this guild.

--- a/include/discpp/webhook.h
+++ b/include/discpp/webhook.h
@@ -7,8 +7,10 @@
 #include "embed_builder.h"
 #include "guild.h"
 #include "user.h"
+#include "http_client.h"
 
 namespace discpp {
+    class HttpClient;
 
     enum WebhookType : int {
         INCOMING = 1,
@@ -18,12 +20,12 @@ namespace discpp {
     // @TODO: Add more endpoints: https://discordapp.com/developers/docs/resources/webhook
 	class Webhook {
 	public:
-	    Webhook() = default;
-	    Webhook(rapidjson::Document& json);
-		Webhook(const Snowflake& id, const std::string& token);
+	    Webhook(std::shared_ptr<HttpClient> http_client);
+	    Webhook(std::shared_ptr<HttpClient> http_client, rapidjson::Document& json);
+		Webhook(std::shared_ptr<HttpClient> http_client, const Snowflake& id, const std::string& token);
 
 		discpp::Message Send(const std::string& text, const bool tts = false, discpp::EmbedBuilder* embed = nullptr, const std::vector<discpp::File>& files = {});
-		void EditName(std::string& name);
+		void EditName(const std::string &name);
 		void Remove();
 
         discpp::Snowflake id = 0;
@@ -35,8 +37,9 @@ namespace discpp {
         std::string token;
 	private:
         uint64_t avatar_hex[2] = {0, 0};
+        std::shared_ptr<HttpClient> http_client;
 
-		ix::WebSocketHttpHeaders Headers(const ix::WebSocketHttpHeaders& add = {});
+        std::map<std::string, std::string, discpp::CaseInsensitiveLess> Headers(const std::map<std::string, std::string, discpp::CaseInsensitiveLess>& add = {});
 	};
 }
 

--- a/src/audit_log.cpp
+++ b/src/audit_log.cpp
@@ -214,7 +214,7 @@ discpp::AuditLogEntry::AuditLogEntry(discpp::Client* client, rapidjson::Document
             rapidjson::Document change_json(rapidjson::kObjectType);
             change_json.CopyFrom(change, change_json.GetAllocator());
 
-            changes.push_back(discpp::AuditLogChange(client, change_json));
+            changes.emplace_back(client, change_json);
         }
     }
     user = discpp::User(client, Snowflake(json["user_id"].GetString()));
@@ -229,7 +229,7 @@ discpp::AuditLog::AuditLog(discpp::Client* client, rapidjson::Document& json) {
         rapidjson::Document webhook_json(rapidjson::kObjectType);
         webhook_json.CopyFrom(webhook, webhook_json.GetAllocator());
 
-        webhooks.push_back(discpp::Webhook(webhook_json));
+        webhooks.push_back(discpp::Webhook(client->http_client, webhook_json));
     }
 
     for (auto const& user : json["user"].GetArray()) {

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -8,30 +8,31 @@
 #include "exceptions.h"
 #include "utils.h"
 #include "client.h"
+#include "http_client.h"
 
 discpp::Cache::Cache(discpp::Client *client) : client(client) {
 
 }
 
-const std::unordered_map<discpp::Snowflake, std::shared_ptr<discpp::Member>> discpp::Cache::GetMembers() {
+const std::unordered_map<discpp::Snowflake, std::shared_ptr<discpp::Member>, discpp::SnowflakeHash> discpp::Cache::GetMembers() {
     std::lock_guard<std::mutex> lock_guard(members_mutex);
 
     return members;
 }
 
-const std::unordered_map<discpp::Snowflake, std::shared_ptr<discpp::Guild>> discpp::Cache::GetGuilds() {
+const std::unordered_map<discpp::Snowflake, std::shared_ptr<discpp::Guild>, discpp::SnowflakeHash> discpp::Cache::GetGuilds() {
     std::lock_guard<std::mutex> lock_guard(guilds_mutex);
 
     return guilds;
 }
 
-const std::unordered_map<discpp::Snowflake, std::shared_ptr<discpp::Message>> discpp::Cache::GetMessages() {
+const std::unordered_map<discpp::Snowflake, std::shared_ptr<discpp::Message>, discpp::SnowflakeHash> discpp::Cache::GetMessages() {
     std::lock_guard<std::mutex> lock_guard(messages_mutex);
 
     return messages;
 }
 
-const std::unordered_map<discpp::Snowflake, discpp::Channel> discpp::Cache::GetPrivateChannels() {
+const std::unordered_map<discpp::Snowflake, discpp::Channel, discpp::SnowflakeHash> discpp::Cache::GetPrivateChannels() {
     std::lock_guard<std::mutex> lock_guard(channels_mutex);
 
     return private_channels;
@@ -71,7 +72,7 @@ std::shared_ptr<discpp::Guild> discpp::Cache::GetGuild(const discpp::Snowflake &
     }
 
     if (can_request) {
-        std::unique_ptr<rapidjson::Document> result = SendGetRequest(client, Endpoint("/guilds/" + std::to_string(guild_id)), DefaultHeaders(client), guild_id, RateLimitBucketType::GUILD);
+        std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/guilds/" + std::to_string(guild_id)), client->http_client->DefaultHeaders(), guild_id, RateLimitBucketType::GUILD);
         auto guild = std::make_shared<discpp::Guild>(client, *result);
         guilds.emplace(guild->id, guild);
         return guild;
@@ -94,7 +95,7 @@ discpp::Channel discpp::Cache::GetChannel(const discpp::Snowflake &id, bool can_
         }
 
         if (can_request) {
-            std::unique_ptr<rapidjson::Document> result = SendGetRequest(client, Endpoint("/channels/" + std::to_string(id)), DefaultHeaders(client), id, RateLimitBucketType::CHANNEL);
+            std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/channels/" + std::to_string(id)), client->http_client->DefaultHeaders(), id, RateLimitBucketType::CHANNEL);
             return discpp::Channel(client, *result);
         } else {
             throw exceptions::DiscordObjectNotFound("Channel not found of id: " + std::to_string(id));
@@ -110,7 +111,7 @@ discpp::Channel discpp::Cache::GetDMChannel(const discpp::Snowflake &id, bool ca
     }
 
     if (can_request) {
-        std::unique_ptr<rapidjson::Document> result = SendGetRequest(client, Endpoint("/channels/" + std::to_string(id)), DefaultHeaders(client), id, RateLimitBucketType::CHANNEL);
+        std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/channels/" + std::to_string(id)), client->http_client->DefaultHeaders(), id, RateLimitBucketType::CHANNEL);
         discpp::Channel channel(client, *result);
 
         private_channels.emplace(channel.id, channel);
@@ -128,7 +129,7 @@ std::shared_ptr<discpp::Member> discpp::Cache::GetMember(const std::shared_ptr<G
     }
 
     if (can_request) {
-        std::unique_ptr<rapidjson::Document> result = SendGetRequest(client, Endpoint("/guilds/" + std::to_string(guild->id) + "/members/" + std::to_string(id)), DefaultHeaders(client), guild->id, RateLimitBucketType::GUILD);
+        std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/guilds/" + std::to_string(guild->id) + "/members/" + std::to_string(id)), client->http_client->DefaultHeaders(), guild->id, RateLimitBucketType::GUILD);
         auto member = std::make_shared<discpp::Member>(client, *result, guild);
         members.emplace(member->user.id, member);
         return member;
@@ -145,8 +146,8 @@ discpp::Message discpp::Cache::GetDiscordMessage(const discpp::Snowflake &channe
     }
 
     if (can_request) {
-        std::unique_ptr<rapidjson::Document> result = SendGetRequest(client, Endpoint("/channels/" + std::to_string(channel_id) + "/messages/" + std::to_string(id)),
-            DefaultHeaders(client), channel_id, RateLimitBucketType::CHANNEL);
+        std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/channels/" + std::to_string(channel_id) + "/messages/" + std::to_string(id)),
+                                                                                          client->http_client->DefaultHeaders(), channel_id, RateLimitBucketType::CHANNEL);
 
         return Message(client, *result);
     } else {
@@ -166,7 +167,7 @@ discpp::User discpp::Cache::GetUser(const discpp::Snowflake &id, bool can_reques
     }
 
     if (can_request) {
-        std::unique_ptr<rapidjson::Document> result = SendGetRequest(client, Endpoint("/users/" + std::to_string(id)), DefaultHeaders(client), id, RateLimitBucketType::GLOBAL);
+        std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/users/" + std::to_string(id)), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GLOBAL);
         return discpp::User(client, *result);
     } else {
         throw exceptions::DiscordObjectNotFound("User not found of id: " + std::to_string(id) + "!");

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -72,12 +72,12 @@ std::shared_ptr<discpp::Guild> discpp::Cache::GetGuild(const discpp::Snowflake &
     }
 
     if (can_request) {
-        std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/guilds/" + std::to_string(guild_id)), client->http_client->DefaultHeaders(), guild_id, RateLimitBucketType::GUILD);
+        std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/guilds/" + (std::string) guild_id), client->http_client->DefaultHeaders(), guild_id, RateLimitBucketType::GUILD);
         auto guild = std::make_shared<discpp::Guild>(client, *result);
         guilds.emplace(guild->id, guild);
         return guild;
     } else {
-        throw exceptions::DiscordObjectNotFound("Guild not found of id: " + std::to_string(guild_id));
+        throw exceptions::DiscordObjectNotFound("Guild not found of id: " + (std::string) guild_id);
     }
 }
 
@@ -95,10 +95,10 @@ discpp::Channel discpp::Cache::GetChannel(const discpp::Snowflake &id, bool can_
         }
 
         if (can_request) {
-            std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/channels/" + std::to_string(id)), client->http_client->DefaultHeaders(), id, RateLimitBucketType::CHANNEL);
+            std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/channels/" + (std::string) id), client->http_client->DefaultHeaders(), id, RateLimitBucketType::CHANNEL);
             return discpp::Channel(client, *result);
         } else {
-            throw exceptions::DiscordObjectNotFound("Channel not found of id: " + std::to_string(id));
+            throw exceptions::DiscordObjectNotFound("Channel not found of id: " + (std::string) id);
         }
     }
 }
@@ -111,13 +111,13 @@ discpp::Channel discpp::Cache::GetDMChannel(const discpp::Snowflake &id, bool ca
     }
 
     if (can_request) {
-        std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/channels/" + std::to_string(id)), client->http_client->DefaultHeaders(), id, RateLimitBucketType::CHANNEL);
+        std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/channels/" + (std::string) id), client->http_client->DefaultHeaders(), id, RateLimitBucketType::CHANNEL);
         discpp::Channel channel(client, *result);
 
         private_channels.emplace(channel.id, channel);
         return channel;
     } else {
-        throw exceptions::DiscordObjectNotFound("DM Channel not found of id: " + std::to_string(id));
+        throw exceptions::DiscordObjectNotFound("DM Channel not found of id: " + (std::string) id);
     }
 }
 
@@ -129,12 +129,12 @@ std::shared_ptr<discpp::Member> discpp::Cache::GetMember(const std::shared_ptr<G
     }
 
     if (can_request) {
-        std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/guilds/" + std::to_string(guild->id) + "/members/" + std::to_string(id)), client->http_client->DefaultHeaders(), guild->id, RateLimitBucketType::GUILD);
+        std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/guilds/" + (std::string) guild->id + "/members/" + (std::string) id), client->http_client->DefaultHeaders(), guild->id, RateLimitBucketType::GUILD);
         auto member = std::make_shared<discpp::Member>(client, *result, guild);
         members.emplace(member->user.id, member);
         return member;
     } else {
-        throw exceptions::DiscordObjectNotFound("Member not found of id: " + std::to_string(id) + ", in guild of id: " + std::to_string(guild->id));
+        throw exceptions::DiscordObjectNotFound("Member not found of id: " + (std::string) id + ", in guild of id: " + (std::string) guild->id);
     }
 }
 
@@ -146,12 +146,12 @@ discpp::Message discpp::Cache::GetDiscordMessage(const discpp::Snowflake &channe
     }
 
     if (can_request) {
-        std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/channels/" + std::to_string(channel_id) + "/messages/" + std::to_string(id)),
-                                                                                          client->http_client->DefaultHeaders(), channel_id, RateLimitBucketType::CHANNEL);
+        std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/channels/" + (std::string) channel_id + "/messages/" + (std::string) id),
+            client->http_client->DefaultHeaders(), channel_id, RateLimitBucketType::CHANNEL);
 
         return Message(client, *result);
     } else {
-        throw exceptions::DiscordObjectNotFound("Message of id \"" + std::to_string(id) + "\" was not found!");
+        throw exceptions::DiscordObjectNotFound("Message of id \"" + (std::string) id + "\" was not found!");
     }
 }
 
@@ -167,9 +167,9 @@ discpp::User discpp::Cache::GetUser(const discpp::Snowflake &id, bool can_reques
     }
 
     if (can_request) {
-        std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/users/" + std::to_string(id)), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GLOBAL);
+        std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/users/" + (std::string) id), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GLOBAL);
         return discpp::User(client, *result);
     } else {
-        throw exceptions::DiscordObjectNotFound("User not found of id: " + std::to_string(id) + "!");
+        throw exceptions::DiscordObjectNotFound("User not found of id: " + (std::string) id + "!");
     }
 }

--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -146,7 +146,7 @@ namespace discpp {
 
             WaitForRateLimits(client, id, RateLimitBucketType::CHANNEL);
 
-            ix::HttpResponsePtr result = http_client->post(Endpoint("/channels/" + std::to_string(id) + "/messages"), body, args);
+            ix::HttpResponsePtr result = http_client->post(Endpoint("/channels/" + (std::string) id + "/messages"), body, args);
 
             client->logger->Debug("Received requested payload: " + result->body);
 
@@ -156,7 +156,7 @@ namespace discpp {
             return discpp::Message(client, result_json);
         }
 
-        std::unique_ptr<rapidjson::Document> result = client->http_client->SendPostRequest(Endpoint("/channels/" + std::to_string(id) + "/messages"), client->http_client->DefaultHeaders({ { "Content-Type", "application/json" } }), id, RateLimitBucketType::CHANNEL, DumpJson(message_json));
+        std::unique_ptr<rapidjson::Document> result = client->http_client->SendPostRequest(Endpoint("/channels/" + (std::string) id + "/messages"), client->http_client->DefaultHeaders({ { "Content-Type", "application/json" } }), id, RateLimitBucketType::CHANNEL, DumpJson(message_json));
 
         return discpp::Message(client, *result);
 	}
@@ -189,7 +189,7 @@ namespace discpp {
             }, variant);
         }
 
-		std::unique_ptr<rapidjson::Document> result = client->http_client->SendPatchRequest(Endpoint("/channels/" + std::to_string(id)), client->http_client->DefaultHeaders({ {"Content-Type", "application/json" } }), id, RateLimitBucketType::CHANNEL, DumpJson(j_body));
+		std::unique_ptr<rapidjson::Document> result = client->http_client->SendPatchRequest(Endpoint("/channels/" + (std::string) id), client->http_client->DefaultHeaders({ {"Content-Type", "application/json" } }), id, RateLimitBucketType::CHANNEL, DumpJson(j_body));
 		
 		*this = discpp::Channel(client, *result);
 		return *this;
@@ -197,19 +197,19 @@ namespace discpp {
 
 	void Channel::Delete() {
         discpp::Client* client = GetClient();
-		std::unique_ptr<rapidjson::Document> result = client->http_client->SendDeleteRequest(Endpoint("/channels/" + std::to_string(id)), client->http_client->DefaultHeaders(), id, RateLimitBucketType::CHANNEL);
+		std::unique_ptr<rapidjson::Document> result = client->http_client->SendDeleteRequest(Endpoint("/channels/" + (std::string) id), client->http_client->DefaultHeaders(), id, RateLimitBucketType::CHANNEL);
 	}
 
 	std::vector<discpp::Message> Channel::RequestMessages(int amount, RequestChannelsMessageMethod get_method) const {
         discpp::Client* client = GetClient();
-	    std::string url = Endpoint("/channels/" + std::to_string(id) + "/messages?limit=" + std::to_string(amount));
+	    std::string url = Endpoint("/channels/" + (std::string) id + "/messages?limit=" + std::to_string(amount));
 
 	    if (get_method.around_id != 0) {
-            url += "&around=" + std::to_string(get_method.around_id);
+            url += "&around=" + (std::string) get_method.around_id;
 	    } else if (get_method.before_id != 0) {
-            url += "&before=" + std::to_string(get_method.before_id);
+            url += "&before=" + (std::string) get_method.before_id;
         } else if (get_method.after_id != 0) {
-            url += "&after=" + std::to_string(get_method.after_id);
+            url += "&after=" + (std::string) get_method.after_id;
         }
 
 		std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(url, client->http_client->DefaultHeaders(), id, RateLimitBucketType::CHANNEL);
@@ -226,19 +226,19 @@ namespace discpp {
 
 	discpp::Message Channel::RequestMessage(const discpp::Snowflake& message_id) {
 	    discpp::Client* client = GetClient();
-		std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/channels/" + std::to_string(id) + "/messages/" + std::to_string(message_id)), client->http_client->DefaultHeaders(), id, RateLimitBucketType::CHANNEL);
+		std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/channels/" + (std::string) id + "/messages/" + (std::string) message_id), client->http_client->DefaultHeaders(), id, RateLimitBucketType::CHANNEL);
 
 		return discpp::Message(client, *result);
 	}
 
 	void Channel::TriggerTypingIndicator() {
         discpp::Client* client = GetClient();
-		std::unique_ptr<rapidjson::Document> result = client->http_client->SendPostRequest(Endpoint("/channels/" + std::to_string(id) + "/typing"), client->http_client->DefaultHeaders(), {}, {});
+		std::unique_ptr<rapidjson::Document> result = client->http_client->SendPostRequest(Endpoint("/channels/" + (std::string) id + "/typing"), client->http_client->DefaultHeaders(), {}, {});
 	}
 
 	std::vector<discpp::Message> Channel::GetPinnedMessages() {
         discpp::Client* client = GetClient();
-        std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/channels/" + std::to_string(id) = "/pins"), client->http_client->DefaultHeaders(), {}, {});
+        std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/channels/" + (std::string) id = "/pins"), client->http_client->DefaultHeaders(), {}, {});
 
         std::vector<discpp::Message> messages;
         for (auto &message : result->GetArray()) {
@@ -251,7 +251,7 @@ namespace discpp {
     }
 
     discpp::Channel Channel::RequestChannel(discpp::Client* client, discpp::Snowflake id) {
-        std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/channels/" + std::to_string(id)), client->http_client->DefaultHeaders(), id, RateLimitBucketType::CHANNEL);
+        std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/channels/" + (std::string) id), client->http_client->DefaultHeaders(), id, RateLimitBucketType::CHANNEL);
         return discpp::Channel(client, *result);
     }
 
@@ -260,14 +260,14 @@ namespace discpp {
             throw std::runtime_error("discpp::Channel::BulkDeleteMessage only available for guild channels!");
         }
 
-		std::string endpoint = Endpoint("/channels/" + std::to_string(id) + "/messages/bulk-delete");
+		std::string endpoint = Endpoint("/channels/" + (std::string) id + "/messages/bulk-delete");
 
 		std::string combined_message = "";
 		for (Snowflake message : messages) {
 			if (message == messages[0]) {
-				combined_message += "\"" + std::to_string(message) + "\"";
+				combined_message += "\"" + (std::string) message + "\"";
 			} else {
-				combined_message += ", \"" + std::to_string(message) + "\"";
+				combined_message += ", \"" + (std::string) message + "\"";
 			}
 		}
 
@@ -283,7 +283,7 @@ namespace discpp {
         }
 
         discpp::Client* client = GetClient();
-        client->http_client->SendDeleteRequest(Endpoint("/channels/" + std::to_string(id) + "/permissions/" + std::to_string(permissions.role_user_id)), client->http_client->DefaultHeaders(), id, RateLimitBucketType::CHANNEL);
+        client->http_client->SendDeleteRequest(Endpoint("/channels/" + (std::string) id + "/permissions/" + (std::string) permissions.role_user_id), client->http_client->DefaultHeaders(), id, RateLimitBucketType::CHANNEL);
     }
 
     void Channel::EditPermissions(const discpp::Permissions& permissions) {
@@ -303,7 +303,7 @@ namespace discpp {
         std::string json_payload = DumpJson(permission_json);
 
         discpp::Client* client = GetClient();
-        client->http_client->SendPutRequest(Endpoint("/channels/" + std::to_string(id) + "/permissions/" + std::to_string(permissions.role_user_id)), client->http_client->DefaultHeaders({ {"Content-Type", "application/json" } }), id, RateLimitBucketType::CHANNEL, json_payload);
+        client->http_client->SendPutRequest(Endpoint("/channels/" + (std::string) id + "/permissions/" + (std::string) permissions.role_user_id), client->http_client->DefaultHeaders({ {"Content-Type", "application/json" } }), id, RateLimitBucketType::CHANNEL, json_payload);
     }
 
     std::shared_ptr<discpp::Guild> Channel::GetGuild() const {
@@ -322,7 +322,7 @@ namespace discpp {
         std::string body("{\"max_age\": " + std::to_string(max_age) + ", \"max_uses\": " + std::to_string(max_uses) + ", \"temporary\": " + std::to_string(temporary) + ", \"unique\": " + std::to_string(unique) + "}");
 
         discpp::Client* client = GetClient();
-        std::unique_ptr<rapidjson::Document> result = client->http_client->SendPostRequest(Endpoint("/channels/" + std::to_string(id) + "/invites"), client->http_client->DefaultHeaders({ {"Content-Type", "application/json" } }), id, RateLimitBucketType::CHANNEL, body);
+        std::unique_ptr<rapidjson::Document> result = client->http_client->SendPostRequest(Endpoint("/channels/" + (std::string) id + "/invites"), client->http_client->DefaultHeaders({ {"Content-Type", "application/json" } }), id, RateLimitBucketType::CHANNEL, body);
         discpp::GuildInvite invite(client, *result);
 
         return invite;
@@ -335,7 +335,7 @@ namespace discpp {
             tmp = std::nullopt;
             //throw std::runtime_error("discpp::Channel::GetInvites only available for guild channels!");
         } else {
-            std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/channels/" + std::to_string(id) + "/invites"), client->http_client->DefaultHeaders(), {}, {});
+            std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/channels/" + (std::string) id + "/invites"), client->http_client->DefaultHeaders(), {}, {});
             for (auto& invite : result->GetArray()) {
                 rapidjson::Document invite_json;
                 invite_json.CopyFrom(invite, invite_json.GetAllocator());
@@ -343,7 +343,7 @@ namespace discpp {
             }
         }
 
-		std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/channels/" + std::to_string(id) + "/invites"), client->http_client->DefaultHeaders(), {}, {});
+		std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/channels/" + (std::string) id + "/invites"), client->http_client->DefaultHeaders(), {}, {});
 		std::vector<discpp::GuildInvite> invites;
 		for (auto& invite : result->GetArray()) {
 			rapidjson::Document invite_json;
@@ -379,7 +379,7 @@ namespace discpp {
 	void Channel::GroupDMAddRecipient(const discpp::User& user) {
         discpp::Client* client = GetClient();
 	    if (type == ChannelType::DM || type == ChannelType::GROUP_DM) {
-            client->http_client->SendPutRequest(Endpoint("/channels/" + std::to_string(id) + "/recipients/" + std::to_string(user.id)), client->http_client->DefaultHeaders(), id, RateLimitBucketType::CHANNEL);
+            client->http_client->SendPutRequest(Endpoint("/channels/" + (std::string) id + "/recipients/" + (std::string) user.id), client->http_client->DefaultHeaders(), id, RateLimitBucketType::CHANNEL);
 		} else {
             client->logger->Debug(LogTextColor::RED + "discpp::Channel::GroupDMAddRecipient only available for DM/Group DM channels!");
 	        throw std::runtime_error("discpp::Channel::GroupDMAddRecipient only available for DM/Group DM channels!");
@@ -389,7 +389,7 @@ namespace discpp {
 	void Channel::GroupDMRemoveRecipient(const discpp::User& user) {
         discpp::Client* client = GetClient();
         if (type == ChannelType::DM || type == ChannelType::GROUP_DM) {
-            client->http_client->SendDeleteRequest(Endpoint("/channels/" + std::to_string(id) + "/recipients/" + std::to_string(user.id)), client->http_client->DefaultHeaders(), id, RateLimitBucketType::CHANNEL);
+            client->http_client->SendDeleteRequest(Endpoint("/channels/" + (std::string) id + "/recipients/" + (std::string) user.id), client->http_client->DefaultHeaders(), id, RateLimitBucketType::CHANNEL);
         } else {
             client->logger->Debug(LogTextColor::RED + "discpp::Channel::GroupDMRemoveRecipient only available for DM/Group DM channels!");
             throw std::runtime_error("discpp::Channel::GroupDMRemoveRecipient only available for DM/Group DM channels!");
@@ -399,7 +399,7 @@ namespace discpp {
     std::string Channel::GetIconURL(const ImageType &img_type) const {
         std::string icon_str = CombineAvatarHash(icon_hex);
 
-        std::string url = "https://cdn.discordapp.com/channel-icons/" + std::to_string(id) + "/" + icon_str;
+        std::string url = "https://cdn.discordapp.com/channel-icons/" + (std::string) id + "/" + icon_str;
         ImageType tmp = img_type;
         if (tmp == ImageType::AUTO) tmp = is_icon_gif ? ImageType::GIF : ImageType::PNG;
         switch (img_type) {

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -14,6 +14,7 @@
 #include "events/reconnect_event.h"
 #include "event_handler.h"
 #include "cache.h"
+#include "http_client.h"
 
 #include <ixwebsocket/IXNetSystem.h>
 #include <memory>
@@ -22,7 +23,7 @@ namespace discpp {
     uint8_t Client::next_instance_id = 0;
     std::map<uint8_t, Client*> Client::client_instances;
 
-    Client::Client(const std::string& token, ClientConfig& config) : token(token), config(config) {
+    Client::Client(const std::string& token, std::shared_ptr<discpp::HttpClient> http_client, ClientConfig& config) : token(token), http_client(std::move(http_client)), config(config) {
         fire_command_method = std::bind(discpp::FireCommand, std::placeholders::_1, std::placeholders::_2);
 
         message_cache_count = config.message_cache_size;
@@ -41,6 +42,8 @@ namespace discpp {
         this->cache = std::make_unique<discpp::Cache>(this);
 
         client_instances.emplace(my_instance_id, this);
+
+        this->http_client->SetClient(this);
     }
 
     Client::~Client() = default;
@@ -52,12 +55,12 @@ namespace discpp {
             rapidjson::Document gateway_request(rapidjson::kObjectType);
             switch (config.type) {
                 case TokenType::USER: {
-                    std::unique_ptr<rapidjson::Document> user_doc = SendGetRequest(this, Endpoint("/gateway"), {{"Authorization", token}, {"User-Agent", "discpp (https://github.com/DisCPP/DisCPP, v0.0.0)"}}, {}, {});
+                    std::unique_ptr<rapidjson::Document> user_doc = http_client->SendGetRequest(Endpoint("/gateway"), {{"Authorization", token}, {"User-Agent", "discpp (https://github.com/DisCPP/DisCPP, v0.0.0)"}}, {}, {});
                     gateway_request.CopyFrom(*user_doc, gateway_request.GetAllocator());
 
                     break;
                 } case TokenType::BOT:
-                    std::unique_ptr<rapidjson::Document> bot_doc = SendGetRequest(this, Endpoint("/gateway/bot"), { {"Authorization", "Bot " + token}, {"User-Agent", "discpp (https://github.com/DisCPP/DisCPP, v0.0.0)"} }, {}, {});
+                    std::unique_ptr<rapidjson::Document> bot_doc = http_client->SendGetRequest(Endpoint("/gateway/bot"), { {"Authorization", "Bot " + token}, {"User-Agent", "discpp (https://github.com/DisCPP/DisCPP, v0.0.0)"} }, {}, {});
                     gateway_request.CopyFrom(*bot_doc, gateway_request.GetAllocator());
 
                     break;
@@ -369,14 +372,14 @@ namespace discpp {
         }
     }
 
-    std::unordered_map<discpp::Snowflake, discpp::Channel> Client::GetUserDMs() {
+    std::unordered_map<discpp::Snowflake, discpp::Channel, discpp::SnowflakeHash> Client::GetUserDMs() {
 
         if (client_user.IsBot()) {
             throw exceptions::ProhibitedEndpointException("/users/@me/channels is a user only endpoint");
         } else {
-            std::unordered_map<discpp::Snowflake, discpp::Channel> dm_channels;
+            std::unordered_map<discpp::Snowflake, discpp::Channel, discpp::SnowflakeHash> dm_channels;
 
-            std::unique_ptr<rapidjson::Document> result = SendGetRequest(this, Endpoint("users/@me/channels"), DefaultHeaders(this), 0, RateLimitBucketType::GLOBAL);
+            std::unique_ptr<rapidjson::Document> result = http_client->SendGetRequest(Endpoint("users/@me/channels"), http_client->DefaultHeaders(), 0, RateLimitBucketType::GLOBAL);
             for (auto const& channel : result->GetArray()) {
                 rapidjson::Document channel_json(rapidjson::kObjectType);
                 channel_json.CopyFrom(channel, channel_json.GetAllocator());
@@ -391,7 +394,7 @@ namespace discpp {
 
     std::vector<discpp::User::Connection> ClientUser::GetUserConnections() {
         discpp::Client* client = GetClient();
-        std::unique_ptr<rapidjson::Document> result = SendGetRequest(client, Endpoint("/users/@me/connections"), DefaultHeaders(client), id, RateLimitBucketType::GLOBAL);
+        std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/users/@me/connections"), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GLOBAL);
 
         std::vector<Connection> connections;
         for (auto const& connection : result->GetArray()) {
@@ -415,7 +418,7 @@ namespace discpp {
             throw exceptions::ProhibitedEndpointException("users/@me/settings is a user only endpoint");
         } else {
             discpp::Client* client = GetClient();
-            std::unique_ptr<rapidjson::Document> result = SendGetRequest(client, Endpoint("users/@me/settings/"), DefaultHeaders(client), 0, RateLimitBucketType::GLOBAL);
+            std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("users/@me/settings/"), client->http_client->DefaultHeaders(), 0, RateLimitBucketType::GLOBAL);
             ClientUserSettings user_settings(*result);
             this->settings = user_settings;
             return user_settings;
@@ -470,7 +473,7 @@ namespace discpp {
             if (user_settings.GetStreamNotificationsEnabled() != old_settings.GetStreamNotificationsEnabled()) new_settings.AddMember("stream_notifications_enabled", user_settings.GetStreamNotificationsEnabled(), allocator);
 
             discpp::Client* client = GetClient();
-            std::unique_ptr<rapidjson::Document> result = SendPatchRequest(client, Endpoint("users/@me/settings/"), DefaultHeaders(client), 0, RateLimitBucketType::GLOBAL, DumpJson(new_settings));
+            std::unique_ptr<rapidjson::Document> result = client->http_client->SendPatchRequest(Endpoint("users/@me/settings/"), client->http_client->DefaultHeaders(), 0, RateLimitBucketType::GLOBAL, DumpJson(new_settings));
         }
     }
 
@@ -478,7 +481,7 @@ namespace discpp {
         if (client_user.IsBot()) {
             throw exceptions::ProhibitedEndpointException("users/@me/relationships is a user only endpoint");
         } else {
-            std::unique_ptr<rapidjson::Document> result = SendPutRequest(this, Endpoint("users/@me/relationships/" + std::to_string(user.id)), DefaultHeaders(this), 0, RateLimitBucketType::GLOBAL);
+            std::unique_ptr<rapidjson::Document> result = http_client->SendPutRequest(Endpoint("users/@me/relationships/" + std::to_string(user.id)), http_client->DefaultHeaders(), 0, RateLimitBucketType::GLOBAL);
         }
     }
 
@@ -486,18 +489,18 @@ namespace discpp {
         if (client_user.IsBot()) {
             throw exceptions::ProhibitedEndpointException("users/@me/relationships is a user only endpoint");
         } else {
-            std::unique_ptr<rapidjson::Document> result = SendDeleteRequest(this, Endpoint("users/@me/relationships/" + std::to_string(user.id)), DefaultHeaders(this), 0, RateLimitBucketType::GLOBAL);
+            std::unique_ptr<rapidjson::Document> result = http_client->SendDeleteRequest(Endpoint("users/@me/relationships/" + std::to_string(user.id)), http_client->DefaultHeaders(), 0, RateLimitBucketType::GLOBAL);
         }
     }
 
-    std::unordered_map<discpp::Snowflake, discpp::UserRelationship> Client::GetRelationships() {
+    std::unordered_map<discpp::Snowflake, discpp::UserRelationship, discpp::SnowflakeHash> Client::GetRelationships() {
         //todo implement this endpoint
         if (client_user.IsBot()) {
             throw exceptions::ProhibitedEndpointException("users/@me/relationships is a user only endpoint");
         } else {
-            std::unordered_map<discpp::Snowflake, discpp::UserRelationship> relationships;
+            std::unordered_map<discpp::Snowflake, discpp::UserRelationship, discpp::SnowflakeHash> relationships;
 
-            std::unique_ptr<rapidjson::Document> result = SendGetRequest(this, Endpoint("users/@me/relationships/"), DefaultHeaders(this), 0, RateLimitBucketType::GLOBAL);
+            std::unique_ptr<rapidjson::Document> result = http_client->SendGetRequest(Endpoint("users/@me/relationships/"), http_client->DefaultHeaders(), 0, RateLimitBucketType::GLOBAL);
             for (auto const& relationship : result->GetArray()) {
                 rapidjson::Document relationship_json(rapidjson::kObjectType);
                 relationship_json.CopyFrom(relationship, relationship_json.GetAllocator());
@@ -511,7 +514,7 @@ namespace discpp {
 
     discpp::User Client::ModifyCurrentUser(const std::string& username, discpp::Image& avatar) {
         std::string body("{\"username\": \"" + username + "\", \"avatar\": " + avatar.ToDataURI() + "}");
-        std::unique_ptr<rapidjson::Document> result = SendPatchRequest(this, Endpoint("/users/@me"), DefaultHeaders(this), 0, discpp::RateLimitBucketType::GLOBAL, body);
+        std::unique_ptr<rapidjson::Document> result = http_client->SendPatchRequest(Endpoint("/users/@me"), http_client->DefaultHeaders(), 0, discpp::RateLimitBucketType::GLOBAL, body);
 
         client_user = discpp::ClientUser(this, *result);
 
@@ -519,7 +522,7 @@ namespace discpp {
     }
 
     void Client::LeaveGuild(const discpp::Guild& guild) {
-        SendDeleteRequest(this, Endpoint("/users/@me/guilds/" + std::to_string(guild.id)), DefaultHeaders(this), 0, RateLimitBucketType::GLOBAL);
+        http_client->SendDeleteRequest(Endpoint("/users/@me/guilds/" + std::to_string(guild.id)), http_client->DefaultHeaders(), 0, RateLimitBucketType::GLOBAL);
     }
 
     void Client::UpdatePresence(discpp::Presence& presence) {
@@ -533,7 +536,7 @@ namespace discpp {
     }
 
     std::vector<discpp::User::Connection> Client::GetBotUserConnections() {
-        std::unique_ptr<rapidjson::Document> result = SendGetRequest(this, Endpoint("/users/@me/connections"), DefaultHeaders(this), 0, RateLimitBucketType::GLOBAL);
+        std::unique_ptr<rapidjson::Document> result = http_client->SendGetRequest(Endpoint("/users/@me/connections"), http_client->DefaultHeaders(), 0, RateLimitBucketType::GLOBAL);
         std::vector<discpp::User::Connection> connections;
         for (auto const& connection : result->GetArray()) {
             rapidjson::Document connection_json;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -481,7 +481,7 @@ namespace discpp {
         if (client_user.IsBot()) {
             throw exceptions::ProhibitedEndpointException("users/@me/relationships is a user only endpoint");
         } else {
-            std::unique_ptr<rapidjson::Document> result = http_client->SendPutRequest(Endpoint("users/@me/relationships/" + std::to_string(user.id)), http_client->DefaultHeaders(), 0, RateLimitBucketType::GLOBAL);
+            std::unique_ptr<rapidjson::Document> result = http_client->SendPutRequest(Endpoint("users/@me/relationships/" + (std::string) user.id), http_client->DefaultHeaders(), 0, RateLimitBucketType::GLOBAL);
         }
     }
 
@@ -489,7 +489,7 @@ namespace discpp {
         if (client_user.IsBot()) {
             throw exceptions::ProhibitedEndpointException("users/@me/relationships is a user only endpoint");
         } else {
-            std::unique_ptr<rapidjson::Document> result = http_client->SendDeleteRequest(Endpoint("users/@me/relationships/" + std::to_string(user.id)), http_client->DefaultHeaders(), 0, RateLimitBucketType::GLOBAL);
+            std::unique_ptr<rapidjson::Document> result = http_client->SendDeleteRequest(Endpoint("users/@me/relationships/" + (std::string) user.id), http_client->DefaultHeaders(), 0, RateLimitBucketType::GLOBAL);
         }
     }
 
@@ -522,7 +522,7 @@ namespace discpp {
     }
 
     void Client::LeaveGuild(const discpp::Guild& guild) {
-        http_client->SendDeleteRequest(Endpoint("/users/@me/guilds/" + std::to_string(guild.id)), http_client->DefaultHeaders(), 0, RateLimitBucketType::GLOBAL);
+        http_client->SendDeleteRequest(Endpoint("/users/@me/guilds/" + (std::string) guild.id), http_client->DefaultHeaders(), 0, RateLimitBucketType::GLOBAL);
     }
 
     void Client::UpdatePresence(discpp::Presence& presence) {

--- a/src/discord_object.cpp
+++ b/src/discord_object.cpp
@@ -14,22 +14,22 @@ namespace discpp {
         }
 	}
 
-	bool DiscordObject::operator==(DiscordObject& other) const {
+	bool DiscordObject::operator==(const DiscordObject& other) const {
 		return this->id == other.id;
 	}
 
-	bool DiscordObject::operator==(Snowflake& other) const {
+	bool DiscordObject::operator==(const Snowflake& other) const {
 		return this->id == other;
 	}
 
 #if __cplusplus <= 201703L || defined(__GNUC__)
-		bool DiscordObject::operator!=(DiscordObject& other) const {
-            return this->id != other.id;
-        }
+    bool DiscordObject::operator!=(const DiscordObject& other) const {
+        return this->id != other.id;
+    }
 
-        bool DiscordObject::operator!=(Snowflake& other) const {
-            return this->id != other;
-        }
+    bool DiscordObject::operator!=(const Snowflake& other) const {
+        return this->id != other;
+    }
 #endif
 
     discpp::Client* DiscordObject::GetClient() const {

--- a/src/embed_builder.cpp
+++ b/src/embed_builder.cpp
@@ -28,7 +28,7 @@ namespace discpp {
 
 	EmbedBuilder& EmbedBuilder::SetTitle(const std::string& title) {
 		if (title.size() < 0 || title.size() > 256) {
-			////client->logger->Error(LogTextColor::RED + "Embed title can only be 0-256 characters!");
+			//client->logger->Error(LogTextColor::RED + "Embed title can only be 0-256 characters!");
 			throw std::runtime_error("Embed title can only be 0-256 characters");
 		}
 		auto& allocator = embed_json.GetAllocator();

--- a/src/guild.cpp
+++ b/src/guild.cpp
@@ -237,14 +237,14 @@ namespace discpp {
 			throw NotGuildOwnerException();
 		}
 
-        client->http_client->SendDeleteRequest(Endpoint("/guilds/" + std::to_string(id)), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD);
+        client->http_client->SendDeleteRequest(Endpoint("/guilds/" + (std::string) id), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD);
 	}
 
     std::unordered_map<discpp::Snowflake, discpp::Channel, discpp::SnowflakeHash> Guild::UpdateChannels() {
         std::lock_guard<std::mutex> lock_guard(channels_mutex);
 
         discpp::Client* client = GetClient();
-		std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/guilds/" + std::to_string(id) + "/channels"), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD);
+		std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/guilds/" + (std::string) id + "/channels"), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD);
         std::unordered_map<discpp::Snowflake, discpp::Channel, discpp::SnowflakeHash> channels;
 
         for (auto const& channel : result->GetArray()) {
@@ -335,7 +335,7 @@ namespace discpp {
         std::string body(DumpJson(channel_json));
 
         discpp::Client* client = GetClient();
-		std::unique_ptr<rapidjson::Document> result = client->http_client->SendPostRequest(Endpoint("/guilds/" + std::to_string(id) + "/channels"), client->http_client->DefaultHeaders( { { "Content-Type", "application/json" } }), id, discpp::RateLimitBucketType::CHANNEL, body);
+		std::unique_ptr<rapidjson::Document> result = client->http_client->SendPostRequest(Endpoint("/guilds/" + (std::string) id + "/channels"), client->http_client->DefaultHeaders( { { "Content-Type", "application/json" } }), id, discpp::RateLimitBucketType::CHANNEL, body);
 
         discpp::Channel channel(client, *result);
         channels.insert({ channel.id, channel });
@@ -359,14 +359,14 @@ namespace discpp {
 
         std::string body(DumpJson(json_raw));
         discpp::Client* client = GetClient();
-        client->http_client->SendPatchRequest(Endpoint("/guilds/" + std::to_string(id) + "/channels"), client->http_client->DefaultHeaders( { { "Content-Type", "application/json" } }), id, discpp::RateLimitBucketType::CHANNEL, body);
+        client->http_client->SendPatchRequest(Endpoint("/guilds/" + (std::string) id + "/channels"), client->http_client->DefaultHeaders( { { "Content-Type", "application/json" } }), id, discpp::RateLimitBucketType::CHANNEL, body);
 	}
 
 	std::shared_ptr<discpp::Member> Guild::GetMember(const Snowflake& id, bool can_request) {
         std::lock_guard<std::mutex> lock_guard(members_mutex);
 
 		if (id == 0) {
-			throw exceptions::DiscordObjectNotFound("Member id: " + std::to_string(id) + " is not valid!");
+			throw exceptions::DiscordObjectNotFound("Member id: " + (std::string) id + " is not valid!");
 		}
 
 		auto it = members.find(id);
@@ -376,13 +376,13 @@ namespace discpp {
 
         if (can_request) {
             discpp::Client* client = GetClient();
-            std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/guilds/" + std::to_string(this->id) + "/members/"+ std::to_string(id)), client->http_client->DefaultHeaders(), id, RateLimitBucketType::CHANNEL);
+            std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/guilds/" + (std::string) this->id + "/members/"+ (std::string) id), client->http_client->DefaultHeaders(), id, RateLimitBucketType::CHANNEL);
 
             auto member = std::make_shared<discpp::Member>(client, *result, this);
             members.emplace(member->user.id, member);
             return member;
         } else {
-            throw exceptions::DiscordObjectNotFound("Member not found of id: " + std::to_string(id));
+            throw exceptions::DiscordObjectNotFound("Member not found of id: " + (std::string) id);
         }
 	}
 
@@ -400,9 +400,9 @@ namespace discpp {
 		std::string json_roles = "[";
 		for (discpp::Role role : roles) {
 			if (&role == &roles.front()) {
-				json_roles += "\"" + std::to_string(role.id) + "\"";
+				json_roles += "\"" + (std::string) role.id + "\"";
 			} else {
-				json_roles += ", \"" + std::to_string(role.id) + "\"";
+				json_roles += ", \"" + (std::string)role.id + "\"";
 			}
 		}
 		json_roles += "]";
@@ -410,19 +410,19 @@ namespace discpp {
         std::string body("{\"access_token\": \"" + access_token + "\", \"nick\": \"" + nick + "\", \"roles\": " + json_roles + ", \"mute\": " + std::to_string(mute) + ", \"deaf\": " + std::to_string(deaf) + "}");
 
         discpp::Client* client = GetClient();
-		std::unique_ptr<rapidjson::Document> result = client->http_client->SendPutRequest(Endpoint("/guilds/" + std::to_string(this->id) + "/members/" + std::to_string(id)), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD, body);
+		std::unique_ptr<rapidjson::Document> result = client->http_client->SendPutRequest(Endpoint("/guilds/" + (std::string) this->id + "/members/" + (std::string) id), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD, body);
 
 		return std::make_shared<discpp::Member>((result->Empty()) ? discpp::Member(client, id, this) : discpp::Member(client, *result, this)); // If the member is already added, return it.
 	}
 
 	void Guild::RemoveMember(const discpp::Member& member) {
         discpp::Client* client = GetClient();
-        client->http_client->SendDeleteRequest(Endpoint("/guilds/" + std::to_string(id) + "/members/" + std::to_string(member.user.id)), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD);
+        client->http_client->SendDeleteRequest(Endpoint("/guilds/" + (std::string) id + "/members/" + (std::string) member.user.id), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD);
 	}
 
 	std::vector<discpp::GuildBan> Guild::GetBans() const {
         discpp::Client* client = GetClient();
-		std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/guilds/" + std::to_string(id) + "/bans"), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD);
+		std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/guilds/" + (std::string) id + "/bans"), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD);
 		
 		std::vector<discpp::GuildBan> guild_bans;
         for (auto const& guild_ban : result->GetArray()) {
@@ -448,7 +448,7 @@ namespace discpp {
 
 	std::string Guild::GetMemberBanReason(const discpp::Member& member) const {
         discpp::Client* client = GetClient();
-		std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/guilds/" + std::to_string(id) + "/bans/" + std::to_string(member.user.id)), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD);
+		std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/guilds/" + (std::string) id + "/bans/" + (std::string) member.user.id), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD);
 		if (ContainsNotNull(*result, "reason")) return (*result)["reason"].GetString();
 
 		return "";
@@ -463,7 +463,7 @@ namespace discpp {
 
         discpp::Client* client = GetClient();
         std::string body("{\"reason\": \"" + EscapeString(reason) + "\"}");
-        client->http_client->SendPutRequest(Endpoint("/guilds/" + std::to_string(id) + "/bans/" + std::to_string(user_id)), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD, body);
+        client->http_client->SendPutRequest(Endpoint("/guilds/" + (std::string) id + "/bans/" + (std::string) user_id), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD, body);
     }
 
 	void Guild::UnbanMember(const discpp::Member& member) {
@@ -474,7 +474,7 @@ namespace discpp {
         Guild::EnsureBotPermission(Permission::BAN_MEMBERS);
 
         discpp::Client* client = GetClient();
-        client->http_client->SendDeleteRequest(Endpoint("/guilds/" + std::to_string(id) + "/bans/" + std::to_string(user_id)), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD);
+        client->http_client->SendDeleteRequest(Endpoint("/guilds/" + (std::string) id + "/bans/" + (std::string) user_id), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD);
     }
 
 	void Guild::KickMember(const discpp::Member& member, const std::string& reason) {
@@ -484,7 +484,7 @@ namespace discpp {
     void Guild::KickMemberById(const Snowflake& member_id, const std::string& reason) {
         Guild::EnsureBotPermission(Permission::KICK_MEMBERS);
 
-        std::string url = Endpoint("guilds/" + std::to_string(id) + "/members/" + std::to_string(member_id));
+        std::string url = Endpoint("guilds/" + (std::string) id + "/members/" + (std::string) member_id);
         if (!reason.empty()) {
             url += "?reason=" + URIEncode(reason);
         }
@@ -516,7 +516,7 @@ namespace discpp {
 
         std::string body(DumpJson(json_body));
         discpp::Client* client = GetClient();
-		std::unique_ptr<rapidjson::Document> result = client->http_client->SendPostRequest(Endpoint("/guilds/" + std::to_string(id) + "/roles"), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD, body);
+		std::unique_ptr<rapidjson::Document> result = client->http_client->SendPostRequest(Endpoint("/guilds/" + (std::string) id + "/roles"), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD, body);
 		std::shared_ptr<discpp::Role> new_role = std::make_shared<discpp::Role>(discpp::Role(client, *result));
 
 		roles.insert({ new_role->id, new_role });
@@ -538,7 +538,7 @@ namespace discpp {
 
         std::string body(DumpJson(json_raw));
         discpp::Client* client = GetClient();
-        client->http_client->SendPatchRequest(Endpoint("/guilds/" + std::to_string(id) + "/roles"), client->http_client->DefaultHeaders( { { "Content-Type", "application/json" } }), id, discpp::RateLimitBucketType::CHANNEL, body);
+        client->http_client->SendPatchRequest(Endpoint("/guilds/" + (std::string) id + "/roles"), client->http_client->DefaultHeaders( { { "Content-Type", "application/json" } }), id, discpp::RateLimitBucketType::CHANNEL, body);
 	}
 
 	std::shared_ptr<discpp::Role> Guild::ModifyRole(const discpp::Role& role, const std::string& name, const Permissions& permissions, const int& color, const bool hoist, const bool mentionable) {
@@ -553,7 +553,7 @@ namespace discpp {
 
         std::string body(DumpJson(json_body));
         discpp::Client* client = GetClient();
-		std::unique_ptr<rapidjson::Document> result = client->http_client->SendPatchRequest(Endpoint("/guilds/" + std::to_string(id) + "/roles/" + std::to_string(role.id)), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD, body);
+		std::unique_ptr<rapidjson::Document> result = client->http_client->SendPatchRequest(Endpoint("/guilds/" + (std::string) id + "/roles/" + (std::string) role.id), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD, body);
 		std::shared_ptr<discpp::Role> modified_role = std::make_shared<discpp::Role>(discpp::Role(client, *result));
 
 		auto it = roles.find(role.id);
@@ -567,7 +567,7 @@ namespace discpp {
 	void Guild::DeleteRole(const discpp::Role& role) {
 		Guild::EnsureBotPermission(Permission::MANAGE_ROLES);
         discpp::Client* client = GetClient();
-        client->http_client->SendDeleteRequest(Endpoint("/guilds/" + std::to_string(id) + "/roles/" + std::to_string(role.id)), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD);
+        client->http_client->SendDeleteRequest(Endpoint("/guilds/" + (std::string) id + "/roles/" + (std::string) role.id), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD);
 
 		roles.erase(role.id);
 	}
@@ -580,7 +580,7 @@ namespace discpp {
         std::string body("{\"days\": " + std::to_string(days) + "}");
 
         discpp::Client* client = GetClient();
-		std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/guilds/" + std::to_string(id) + "/prune"), client->http_client->DefaultHeaders( { { "Content-Type", "application/json" } }), id, discpp::RateLimitBucketType::GUILD, body);
+		std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/guilds/" + (std::string) id + "/prune"), client->http_client->DefaultHeaders( { { "Content-Type", "application/json" } }), id, discpp::RateLimitBucketType::GUILD, body);
 
 		return GetDataSafely<int>(*result, "pruned");
 	}
@@ -588,12 +588,12 @@ namespace discpp {
 	void Guild::BeginPrune(const int& days) {
         std::string body("{\"days\": " + std::to_string(days) + "}");
         discpp::Client* client = GetClient();
-        client->http_client->SendPostRequest(Endpoint("/guilds/" + std::to_string(id) + "/prune"), client->http_client->DefaultHeaders( { { "Content-Type", "application/json" } }), id, discpp::RateLimitBucketType::GUILD, body);
+        client->http_client->SendPostRequest(Endpoint("/guilds/" + (std::string) id + "/prune"), client->http_client->DefaultHeaders( { { "Content-Type", "application/json" } }), id, discpp::RateLimitBucketType::GUILD, body);
 	}
 
 	std::vector<discpp::GuildInvite> Guild::GetInvites() const {
         discpp::Client* client = GetClient();
-		std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/guilds/" + std::to_string(id) + "/invites"), client->http_client->DefaultHeaders(), {}, {});
+		std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/guilds/" + (std::string) id + "/invites"), client->http_client->DefaultHeaders(), {}, {});
 
 		std::vector<discpp::GuildInvite> guild_invites;
         for (auto const& guild_invite : result->GetArray()) {
@@ -610,7 +610,7 @@ namespace discpp {
 
 	std::vector<discpp::Integration> Guild::GetIntegrations() const {
         discpp::Client* client = GetClient();
-		std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/guilds/" + std::to_string(id) + "/integrations"), client->http_client->DefaultHeaders(), {}, {});
+		std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/guilds/" + (std::string) id + "/integrations"), client->http_client->DefaultHeaders(), {}, {});
 
 		std::vector<discpp::Integration> guild_integrations;
 		for (auto const& guild_integration : result->GetArray()) {
@@ -628,9 +628,9 @@ namespace discpp {
 	void Guild::CreateIntegration(const Snowflake& id, const std::string& type) {
 		Guild::EnsureBotPermission(Permission::MANAGE_GUILD);
 
-        std::string body("{\"type\": \"" + type + "\", \"id\": \"" + std::to_string(id) + "\"}");
+        std::string body("{\"type\": \"" + type + "\", \"id\": \"" + (std::string) id + "\"}");
         discpp::Client* client = GetClient();
-        client->http_client->SendPostRequest(Endpoint("/guilds/" + std::to_string(this->id) + "/integrations"), client->http_client->DefaultHeaders(), this->id, RateLimitBucketType::GUILD, body);
+        client->http_client->SendPostRequest(Endpoint("/guilds/" + (std::string) this->id + "/integrations"), client->http_client->DefaultHeaders(), this->id, RateLimitBucketType::GUILD, body);
 	}
 
 	void Guild::ModifyIntegration(const discpp::Integration& guild_integration, const int& expire_behavior, const int& expire_grace_period, const bool enable_emoticons) {
@@ -638,33 +638,33 @@ namespace discpp {
 
         std::string body("{\"expire_behavior\": " + std::to_string(expire_behavior) + ", \"expire_grace_period\": " + std::to_string(expire_grace_period) + ", \"enable_emoticons\": " + std::to_string(enable_emoticons) + "}");
         discpp::Client* client = GetClient();
-        client->http_client->SendPostRequest(Endpoint("/guilds/" + std::to_string(id) + "/integrations/" + std::to_string(guild_integration.id)), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD, body);
+        client->http_client->SendPostRequest(Endpoint("/guilds/" + (std::string) id + "/integrations/" + (std::string) guild_integration.id), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD, body);
 	}
 
 	void Guild::DeleteIntegration(const discpp::Integration& guild_integration) {
 		Guild::EnsureBotPermission(Permission::MANAGE_GUILD);
 
         discpp::Client* client = GetClient();
-        client->http_client->SendDeleteRequest(Endpoint("/guilds/" + std::to_string(id) + "/integrations/" + std::to_string(guild_integration.id)), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD);
+        client->http_client->SendDeleteRequest(Endpoint("/guilds/" + (std::string) id + "/integrations/" + (std::string) guild_integration.id), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD);
 	}
 
 	void Guild::SyncIntegration(const discpp::Integration& guild_integration) {
 		Guild::EnsureBotPermission(Permission::MANAGE_GUILD);
 
         discpp::Client* client = GetClient();
-        client->http_client->SendPostRequest(Endpoint("/guilds/" + std::to_string(id) + "/integrations/" + std::to_string(guild_integration.id) + "/sync"), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD);
+        client->http_client->SendPostRequest(Endpoint("/guilds/" + (std::string) id + "/integrations/" + (std::string) guild_integration.id + "/sync"), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD);
 	}
 
 	discpp::GuildEmbed Guild::GetGuildEmbed() const {
         discpp::Client* client = GetClient();
-		std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/guilds/" + std::to_string(id) + "/embed"), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD);
+		std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/guilds/" + (std::string) id + "/embed"), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD);
 		return discpp::GuildEmbed(*result);
 	}
 
 	discpp::GuildEmbed Guild::ModifyGuildEmbed(const Snowflake& channel_id, const bool enabled) {
-        std::string body("{\"channel_id\": \"" + std::to_string(channel_id) + "\", \"enabled\": " + ((enabled) ? "true" : "false") + "}");
+        std::string body("{\"channel_id\": \"" + (std::string) channel_id + "\", \"enabled\": " + ((enabled) ? "true" : "false") + "}");
         discpp::Client* client = GetClient();
-        std::unique_ptr<rapidjson::Document> result = client->http_client->SendPatchRequest(Endpoint("/guilds/" + std::to_string(id) + "/embed"), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD, body);
+        std::unique_ptr<rapidjson::Document> result = client->http_client->SendPatchRequest(Endpoint("/guilds/" + (std::string) id + "/embed"), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD, body);
 
 		return discpp::GuildEmbed(*result);
 	}
@@ -691,7 +691,7 @@ namespace discpp {
 		}
         std::string body("{\"style\": " + style + "}");
         discpp::Client* client = GetClient();
-		std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/guilds/" + std::to_string(id) + "/widget.png"), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD, body);
+		std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/guilds/" + (std::string) id + "/widget.png"), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD, body);
 
 		return result->GetString();
 	}
@@ -700,7 +700,7 @@ namespace discpp {
         std::lock_guard<std::mutex> lock_guard(emojis_mutex);
 
         discpp::Client* client = GetClient();
-		std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/guilds/" + std::to_string(id) + "/emojis"), client->http_client->DefaultHeaders(), {}, {});
+		std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/guilds/" + (std::string) id + "/emojis"), client->http_client->DefaultHeaders(), {}, {});
 
 		std::unordered_map<Snowflake, Emoji, discpp::SnowflakeHash> emojis;
         for (auto const& emoji : result->GetArray()) {
@@ -721,7 +721,7 @@ namespace discpp {
         std::lock_guard<std::mutex> lock_guard(emojis_mutex);
 
         if (id == 0) {
-            throw exceptions::DiscordObjectNotFound("Member id: " + std::to_string(id) + " is not valid!");
+            throw exceptions::DiscordObjectNotFound("Member id: " + (std::string) id + " is not valid!");
         }
 
         auto it = emojis.find(id);
@@ -731,13 +731,13 @@ namespace discpp {
 
         if (can_request) {
             discpp::Client* client = GetClient();
-            std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/guilds/" + std::to_string(this->id) + "/emojis/" + std::to_string(id)), client->http_client->DefaultHeaders(), {}, {});
+            std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/guilds/" + (std::string) this->id + "/emojis/" + (std::string) id), client->http_client->DefaultHeaders(), {}, {});
 
             discpp::Emoji emoji(client, *result);
             emojis.emplace(emoji.id, emoji);
             return emoji;
         } else {
-            throw exceptions::DiscordObjectNotFound("Member not found of id: " + std::to_string(id));
+            throw exceptions::DiscordObjectNotFound("Member not found of id: " + (std::string) id);
         }
 	}
 
@@ -756,7 +756,7 @@ namespace discpp {
 
         std::string body(DumpJson(body_raw));
         discpp::Client* client = GetClient();
-		std::unique_ptr<rapidjson::Document> result = client->http_client->SendPostRequest(Endpoint("/guilds/" + std::to_string(id) + "/emojis"), client->http_client->DefaultHeaders( { { "Content-Type", "application/json" } }), id, RateLimitBucketType::GUILD, body);
+		std::unique_ptr<rapidjson::Document> result = client->http_client->SendPostRequest(Endpoint("/guilds/" + (std::string) id + "/emojis"), client->http_client->DefaultHeaders( { { "Content-Type", "application/json" } }), id, RateLimitBucketType::GUILD, body);
 
         Emoji emoji = discpp::Emoji(client, *result);
         emojis.insert({ emoji.id, emoji });
@@ -769,17 +769,17 @@ namespace discpp {
 		std::string json_roles = "[";
 		for (discpp::Role role : roles) {
 			if (&role == &roles.front()) {
-				json_roles += "\"" + std::to_string(role.id) + "\"";
+				json_roles += "\"" + (std::string) role.id + "\"";
 			}
 			else {
-				json_roles += ", \"" + std::to_string(role.id) + "\"";
+				json_roles += ", \"" + (std::string) role.id + "\"";
 			}
 		}
 		json_roles += "]";
 
         std::string body("{\"name\": \"" + name + "\", \"roles\": " + json_roles + "}");
         discpp::Client* client = GetClient();
-		std::unique_ptr<rapidjson::Document> result = client->http_client->SendPatchRequest(Endpoint("/guilds/" + std::to_string(this->id) + "/emojis/" + std::to_string(id)), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD, body);
+		std::unique_ptr<rapidjson::Document> result = client->http_client->SendPatchRequest(Endpoint("/guilds/" + (std::string) this->id + "/emojis/" + (std::string) id), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD, body);
 
 		discpp::Emoji resulted_emoji = discpp::Emoji(client, *result);
 
@@ -794,7 +794,7 @@ namespace discpp {
 	void Guild::DeleteEmoji(const discpp::Emoji& emoji) {
 		Guild::EnsureBotPermission(Permission::MANAGE_EMOJIS);
         discpp::Client* client = GetClient();
-        client->http_client->SendDeleteRequest(Endpoint("/guilds/" + std::to_string(this->id) + "/emojis/" + std::to_string(id)), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD);
+        client->http_client->SendDeleteRequest(Endpoint("/guilds/" + (std::string) this->id + "/emojis/" + (std::string) id), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD);
 
 		emojis.erase(emoji.id);
 	}
@@ -803,7 +803,7 @@ namespace discpp {
 	    std::string icon_str = CombineAvatarHash(icon_hex);
 
 		discpp::ImageType tmp;
-		std::string url = "https://cdn.discordapp.com/icons/" + std::to_string(id) +  "/" + icon_str;
+		std::string url = "https://cdn.discordapp.com/icons/" + (std::string) id +  "/" + icon_str;
 		tmp = img_type;
 		if (tmp == ImageType::AUTO) tmp = is_icon_gif ? ImageType::GIF : ImageType::PNG;
 		switch (tmp) {
@@ -904,7 +904,7 @@ namespace discpp {
         }
 
         std::string body(DumpJson(j_body));
-        std::unique_ptr<rapidjson::Document> result = client->http_client->SendPatchRequest(Endpoint("/guilds/" + std::to_string(id)), client->http_client->DefaultHeaders( { { "Content-Type", "application/json" } }), id, RateLimitBucketType::CHANNEL, body);
+        std::unique_ptr<rapidjson::Document> result = client->http_client->SendPatchRequest(Endpoint("/guilds/" + (std::string) id), client->http_client->DefaultHeaders( { { "Content-Type", "application/json" } }), id, RateLimitBucketType::CHANNEL, body);
 
         *this = discpp::Guild(client, *result);
         return *this;
@@ -912,14 +912,14 @@ namespace discpp {
 
     discpp::GuildInvite Guild::GetVanityURL() const {
         discpp::Client* client = GetClient();
-	    std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/guilds/" + std::to_string(id) + "/vanity-url"), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD);
+	    std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/guilds/" + (std::string) id + "/vanity-url"), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD);
 
         return discpp::GuildInvite(client, *result);
     }
 
     discpp::AuditLog Guild::GetAuditLog() const {
         discpp::Client* client = GetClient();
-        std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/guilds/" + std::to_string(id) + "/audit-logs"), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD);
+        std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/guilds/" + (std::string) id + "/audit-logs"), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD);
 
         return discpp::AuditLog(client, *result);
     }
@@ -950,7 +950,7 @@ namespace discpp {
             return it->second;
         } else {
             discpp::Client* client = GetClient();
-            std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/guilds/" + std::to_string(id) + "/members/" + std::to_string(member_id)), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD);
+            std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/guilds/" + (std::string) id + "/members/" + (std::string) member_id), client->http_client->DefaultHeaders(), id, RateLimitBucketType::GUILD);
 
             std::shared_ptr<discpp::Member> member = std::make_shared<discpp::Member>(client, *result, this);
             members.insert({ member_id, member });
@@ -963,7 +963,7 @@ namespace discpp {
         std::string banner_str = CombineAvatarHash(banner_hex);
 
         discpp::ImageType tmp = img_type;
-        std::string url = "https://cdn.discordapp.com/banners/" + std::to_string(id) +  "/" + banner_str;
+        std::string url = "https://cdn.discordapp.com/banners/" + (std::string) id +  "/" + banner_str;
 
         if (tmp == ImageType::AUTO) tmp = ImageType::PNG;
         switch (tmp) {
@@ -984,7 +984,7 @@ namespace discpp {
         std::string banner_str = CombineAvatarHash(banner_hex);
 
         discpp::ImageType tmp = img_type;
-        std::string url = "https://cdn.discordapp.com/splashes/" + std::to_string(id) +  "/" + banner_str;
+        std::string url = "https://cdn.discordapp.com/splashes/" + (std::string) id +  "/" + banner_str;
 
         if (tmp == ImageType::AUTO) tmp = ImageType::PNG;
         switch (tmp) {
@@ -1005,7 +1005,7 @@ namespace discpp {
         std::string banner_str = CombineAvatarHash(banner_hex);
 
         discpp::ImageType tmp = img_type;
-        std::string url = "https://cdn.discordapp.com/discovery-splashes/" + std::to_string(id) +  "/" + banner_str;
+        std::string url = "https://cdn.discordapp.com/discovery-splashes/" + (std::string) id +  "/" + banner_str;
 
         if (tmp == ImageType::AUTO) tmp = ImageType::PNG;
         switch (tmp) {

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -1,0 +1,86 @@
+#include "http_client.h"
+#include "exceptions.h"
+#include "client.h"
+#include "log.h"
+#include "client_config.h"
+
+std::map<std::string, std::string, discpp::CaseInsensitiveLess> discpp::HttpClient::DefaultHeaders(std::map<std::string, std::string, CaseInsensitiveLess> add) {
+    std::map<std::string, std::string, discpp::CaseInsensitiveLess> headers = {
+            { "User-Agent", "DiscordBot (https://github.com/seanomik/DisCPP, v0.0.0)" },
+            { "X-RateLimit-Precision", "millisecond"}};
+
+    // Add the correct authorization header depending on the token type.
+    if (client->config.type == TokenType::USER) {
+        headers.insert({ "Authorization", client->token });
+    } else {
+        headers.insert({ "Authorization", "Bot " + client->token });
+    }
+
+    for (auto head : add) {
+        headers.insert(headers.end(), head);
+    }
+
+    return headers;
+}
+
+std::unique_ptr<rapidjson::Document> discpp::HttpClient::HandleResponse(std::string response_body, int status_code, const std::map<std::string, std::string, CaseInsensitiveLess> &headers,
+        discpp::RateLimitBucketType ratelimit_bucket, discpp::Snowflake object) {
+
+    if (client) {
+        client->logger->Debug("Received requested payload: " + response_body);
+    }
+
+    auto tmp = std::make_unique<rapidjson::Document>();
+    if (!response_body.empty() && response_body[0] == '[' && response_body[response_body.size() - 1] == ']') {
+        tmp->SetArray();
+    } else {
+        tmp->SetObject();
+    }
+
+    // Handle http response codes and throw an exception if it failed.
+    if (status_code != 200 && status_code != 201 && status_code != 204) {
+        std::string response_msg;
+        switch (status_code) {
+            case 304:
+                response_msg = "NOT MODIFIED";
+                break;
+            case 400:
+                response_msg = "BAD REQUEST";
+                break;
+            case 401:
+                response_msg = "UNAUTHORIZED";
+                break;
+            case 403:
+                response_msg = "FORBIDDEN";
+                break;
+            case 404:
+                response_msg = "NOT FOUND";
+                break;
+            case 405:
+                response_msg = "METHOD NOT ALLOWED";
+                break;
+            case 249:
+                response_msg = "TOO MANY REQUESTS";
+                break;
+            case 502:
+                response_msg = "GATEWAY UNAVAILABLE";
+                break;
+            default:
+                response_msg = "SERVER ERROR";
+                break;
+        }
+
+        throw discpp::exceptions::http::HTTPResponseException(status_code, response_msg);
+    }
+
+    discpp::HandleRateLimits(headers, object, ratelimit_bucket);
+    tmp->Parse((!response_body.empty() ? response_body.c_str() : "{}"));
+
+    // Check if we were returned a json error and throw an exception if so.
+    if (!tmp->IsNull() && tmp->IsObject() && ContainsNotNull(*tmp, "code")) {
+        discpp::ThrowException(*tmp);
+    }
+
+    // This shows an error in inteliisense for some reason but compiles fine.
+    return tmp;
+}

--- a/src/ixweb_http_client.cpp
+++ b/src/ixweb_http_client.cpp
@@ -1,0 +1,133 @@
+//
+// Created by sean_ on 12/21/2020.
+//
+
+#include "ixweb_http_client.h"
+#include "client.h"
+#include "log.h"
+#include "client_config.h"
+#include "exceptions.h"
+
+#include <ixwebsocket/IXNetSystem.h>
+#include <ixwebsocket/IXHttpClient.h>
+
+std::unique_ptr<rapidjson::Document> discpp::IXWebHttpClient::SendGetRequest(std::string url, std::map<std::string, std::string, discpp::CaseInsensitiveLess> headers, discpp::Snowflake object,
+        discpp::RateLimitBucketType ratelimit_bucket, std::string body) {
+
+    if (client != nullptr) {
+        client->logger->Debug("Sending get request, URL: " + url + ", body: " + body);
+    }
+
+    ix::initNetSystem();
+
+    WaitForRateLimits(client, object, ratelimit_bucket);
+
+    ix::HttpClient httpClient;
+    ix::HttpRequestArgsPtr args = httpClient.createRequest();
+    args->extraHeaders = ix::WebSocketHttpHeaders(headers.begin(), headers.end());
+    args->body = body;
+    ix::HttpResponsePtr result;
+    result = httpClient.get(url, args);
+
+    std::unique_ptr<rapidjson::Document> doc = HandleResponse(result->body, result->statusCode,
+        std::map<std::string, std::string, discpp::CaseInsensitiveLess>(result->headers.begin(), result->headers.end()),
+            ratelimit_bucket, object);
+
+    return doc;
+}
+
+std::unique_ptr<rapidjson::Document> discpp::IXWebHttpClient::SendPostRequest(std::string url, std::map<std::string, std::string, discpp::CaseInsensitiveLess> headers, discpp::Snowflake object,
+        discpp::RateLimitBucketType ratelimit_bucket, std::string body) {
+
+    if (client != nullptr) {
+        client->logger->Debug("Sending post request, URL: " + url + ", body: " + body);
+    }
+
+    ix::initNetSystem();
+
+    WaitForRateLimits(client, object, ratelimit_bucket);
+
+    ix::HttpClient httpClient;
+    ix::HttpRequestArgsPtr args = httpClient.createRequest();
+    args->extraHeaders = ix::WebSocketHttpHeaders(headers.begin(), headers.end());
+    ix::HttpResponsePtr result;
+    result = httpClient.post(url, body, args);
+
+    std::unique_ptr<rapidjson::Document> doc = HandleResponse(result->body, result->statusCode,
+        std::map<std::string, std::string, discpp::CaseInsensitiveLess>(result->headers.begin(), result->headers.end()),
+            ratelimit_bucket, object);
+
+    return doc;
+}
+
+std::unique_ptr<rapidjson::Document> discpp::IXWebHttpClient::SendPutRequest(std::string url, std::map<std::string, std::string, discpp::CaseInsensitiveLess> headers, discpp::Snowflake object,
+        discpp::RateLimitBucketType ratelimit_bucket, std::string body) {
+
+    if (client != nullptr) {
+        client->logger->Debug("Sending get request, URL: " + url + ", body: " + body);
+    }
+
+    ix::initNetSystem();
+
+    WaitForRateLimits(client, object, ratelimit_bucket);
+
+    ix::HttpClient httpClient;
+    ix::HttpRequestArgsPtr args = httpClient.createRequest();
+    args->extraHeaders = ix::WebSocketHttpHeaders(headers.begin(), headers.end());
+    ix::HttpResponsePtr result;
+    result = httpClient.put(url, body, args);
+
+    std::unique_ptr<rapidjson::Document> doc = HandleResponse(result->body, result->statusCode,
+        std::map<std::string, std::string, discpp::CaseInsensitiveLess>(result->headers.begin(), result->headers.end()),
+            ratelimit_bucket, object);
+
+    return doc;
+}
+
+std::unique_ptr<rapidjson::Document> discpp::IXWebHttpClient::SendPatchRequest(std::string url, std::map<std::string, std::string, discpp::CaseInsensitiveLess> headers, discpp::Snowflake object,
+        discpp::RateLimitBucketType ratelimit_bucket, std::string body) {
+
+    if (client != nullptr) {
+        client->logger->Debug("Sending patch request, URL: " + url + ", body: " + body);
+    }
+
+    ix::initNetSystem();
+
+    WaitForRateLimits(client, object, ratelimit_bucket);
+
+    ix::HttpClient httpClient;
+    ix::HttpRequestArgsPtr args = httpClient.createRequest();
+    args->extraHeaders = ix::WebSocketHttpHeaders(headers.begin(), headers.end());
+    ix::HttpResponsePtr result;
+    result = httpClient.patch(url, body, args);
+
+    std::unique_ptr<rapidjson::Document> doc = HandleResponse(result->body, result->statusCode,
+        std::map<std::string, std::string, discpp::CaseInsensitiveLess>(result->headers.begin(), result->headers.end()),
+            ratelimit_bucket, object);
+
+    return doc;
+}
+
+std::unique_ptr<rapidjson::Document> discpp::IXWebHttpClient::SendDeleteRequest(std::string url, std::map<std::string, std::string, discpp::CaseInsensitiveLess> headers, discpp::Snowflake object,
+        discpp::RateLimitBucketType ratelimit_bucket) {
+
+    if (client != nullptr) {
+        client->logger->Debug("Sending delete request, URL: " + url);
+    }
+
+    ix::initNetSystem();
+
+    WaitForRateLimits(client, object, ratelimit_bucket);
+
+    ix::HttpClient httpClient;
+    ix::HttpRequestArgsPtr args = httpClient.createRequest();
+    args->extraHeaders = ix::WebSocketHttpHeaders(headers.begin(), headers.end());
+    ix::HttpResponsePtr result;
+    result = httpClient.del(url, args);
+
+    std::unique_ptr<rapidjson::Document> doc = HandleResponse(result->body, result->statusCode,
+        std::map<std::string, std::string, discpp::CaseInsensitiveLess>(result->headers.begin(), result->headers.end()),
+        ratelimit_bucket, object);
+
+    return doc;
+}

--- a/src/member.cpp
+++ b/src/member.cpp
@@ -71,10 +71,10 @@ namespace discpp {
 		std::string json_roles = "[";
 		for (discpp::Role role : roles) {
 			if (&role == &roles.front()) {
-				json_roles += "\"" + std::to_string(role.id) + "\"";
+				json_roles += "\"" + (std::string) role.id + "\"";
 			}
 			else {
-				json_roles += ", \"" + std::to_string(role.id) + "\"";
+				json_roles += ", \"" + (std::string) role.id + "\"";
 			}
 		}
 		json_roles += "]";
@@ -92,27 +92,27 @@ namespace discpp {
 			}
 		}
 
-		std::string body("{\"nick\": \"" + EscapeString(nick) + "\", \"roles\": " + json_roles + ", \"mute\": " + std::to_string(mute) + ", \"deaf\": " + std::to_string(deaf) + "\"channel_id\": \"" + std::to_string(channel_id) + "\"" + "}");
+		std::string body("{\"nick\": \"" + EscapeString(nick) + "\", \"roles\": " + json_roles + ", \"mute\": " + std::to_string(mute) + ", \"deaf\": " + std::to_string(deaf) + "\"channel_id\": \"" + (std::string) channel_id + "\"" + "}");
 
 		discpp::Client* client = user.GetClient();
-        client->http_client->SendPatchRequest( Endpoint("/guilds/" + std::to_string(this->user.id) + "/members/" + std::to_string(user.id)), client->http_client->DefaultHeaders({ { "Content-Type", "application/json" } }), guild_id, RateLimitBucketType::GUILD, body);
+        client->http_client->SendPatchRequest( Endpoint("/guilds/" + (std::string) this->user.id + "/members/" + (std::string) user.id), client->http_client->DefaultHeaders({ { "Content-Type", "application/json" } }), guild_id, RateLimitBucketType::GUILD, body);
 	}
 
 	void Member::AddRole(const discpp::Role& role) {
         discpp::Client* client = user.GetClient();
-        client->http_client->SendPutRequest(Endpoint("/guilds/" + std::to_string(guild_id) + "/members/" + std::to_string(user.id) + "/roles/" + std::to_string(role.id)), client->http_client->DefaultHeaders(), guild_id, RateLimitBucketType::GUILD);
+        client->http_client->SendPutRequest(Endpoint("/guilds/" + (std::string) guild_id + "/members/" + (std::string) user.id + "/roles/" + (std::string) role.id), client->http_client->DefaultHeaders(), guild_id, RateLimitBucketType::GUILD);
 	}
 
 	void Member::RemoveRole(const discpp::Role& role) {
         discpp::Client* client = user.GetClient();
-        client->http_client->SendDeleteRequest(Endpoint("/guilds/" + std::to_string(guild_id) + "/members/" + std::to_string(user.id) + "/roles/" + std::to_string(role.id)), client->http_client->DefaultHeaders(), guild_id, RateLimitBucketType::GUILD);
+        client->http_client->SendDeleteRequest(Endpoint("/guilds/" + (std::string) guild_id + "/members/" + (std::string) user.id + "/roles/" + (std::string) role.id), client->http_client->DefaultHeaders(), guild_id, RateLimitBucketType::GUILD);
 	}
 
 	bool Member::IsBanned() {
         discpp::Client* client = user.GetClient();
 
         try {
-            std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/guilds/" + std::to_string(guild_id) + "/bans/" + std::to_string(user.id)), client->http_client->DefaultHeaders(), guild_id, RateLimitBucketType::GUILD);
+            std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(Endpoint("/guilds/" + (std::string) guild_id + "/bans/" + (std::string) user.id), client->http_client->DefaultHeaders(), guild_id, RateLimitBucketType::GUILD);
 
             return true;
 		} catch (const exceptions::http::HTTPResponseException& e) {

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -139,28 +139,28 @@ namespace discpp {
 	void Message::AddReaction(const discpp::Emoji& emoji) {
         discpp::Emoji tmp = emoji;
 
-		std::string endpoint = Endpoint("/channels/" + std::to_string(channel.id) + "/messages/" + std::to_string(id) + "/reactions/" + tmp.ToURL() + "/@me");
+		std::string endpoint = Endpoint("/channels/" + (std::string) channel.id + "/messages/" + (std::string) id + "/reactions/" + tmp.ToURL() + "/@me");
         discpp::Client* client = GetClient();
         client->http_client->SendPutRequest(endpoint, client->http_client->DefaultHeaders(), channel.id, RateLimitBucketType::CHANNEL);
 	}
 
 	void Message::RemoveBotReaction(const discpp::Emoji& emoji) {
         discpp::Emoji tmp = emoji;
-		std::string endpoint = Endpoint("/channels/" + std::to_string(channel.id) + "/messages/" + std::to_string(id) + "/reactions/" + tmp.ToURL() + "/@me");
+		std::string endpoint = Endpoint("/channels/" + (std::string) channel.id + "/messages/" + (std::string) id + "/reactions/" + tmp.ToURL() + "/@me");
         discpp::Client* client = GetClient();
         client->http_client->SendDeleteRequest(endpoint, client->http_client->DefaultHeaders(), channel.id, RateLimitBucketType::CHANNEL);
 	}
 
 	void Message::RemoveReaction(const discpp::User& user, const discpp::Emoji& emoji) {
         discpp::Emoji tmp = emoji;
-		std::string endpoint = Endpoint("/channels/" + std::to_string(channel.id) + "/messages/" + std::to_string(id) + "/reactions/" + tmp.ToURL() + "/" + std::to_string(user.id));
+		std::string endpoint = Endpoint("/channels/" + (std::string) channel.id + "/messages/" + (std::string) id + "/reactions/" + tmp.ToURL() + "/" + (std::string) user.id);
         discpp::Client* client = GetClient();
         client->http_client->SendDeleteRequest(endpoint, client->http_client->DefaultHeaders(), channel.id, RateLimitBucketType::CHANNEL);
 	}
 
 	std::unordered_map<discpp::Snowflake, discpp::User, discpp::SnowflakeHash> Message::GetReactorsOfEmoji(const discpp::Emoji& emoji, const int& amount) {
         discpp::Emoji tmp = emoji;
-		std::string endpoint = Endpoint("/channels/" + std::to_string(channel.id) + "/messages/" + std::to_string(id) + "/reactions/" + tmp.ToURL());
+		std::string endpoint = Endpoint("/channels/" + (std::string) channel.id + "/messages/" + (std::string) id + "/reactions/" + tmp.ToURL());
         std::string body("{\"limit\": " + std::to_string(amount) + "}");
         discpp::Client* client = GetClient();
 		std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(endpoint, client->http_client->DefaultHeaders(), channel.id, RateLimitBucketType::CHANNEL, body);
@@ -176,9 +176,9 @@ namespace discpp {
 
 	std::unordered_map<discpp::Snowflake, discpp::User, discpp::SnowflakeHash> Message::GetReactorsOfEmoji(const discpp::Emoji& emoji, const discpp::User& user, const GetReactionsMethod& method) {
         discpp::Emoji tmp = emoji;
-		std::string endpoint = Endpoint("/channels/" + std::to_string(channel.id) + "/messages/" + std::to_string(id) + "/reactions/" + tmp.ToURL());
+		std::string endpoint = Endpoint("/channels/" + (std::string) channel.id + "/messages/" + (std::string) id + "/reactions/" + tmp.ToURL());
 		std::string method_str = (method == GetReactionsMethod::BEFORE_USER) ? "before" : "after";
-        std::string body("{\"" + method_str + "\": " + std::to_string(user.id) + "}");
+        std::string body("{\"" + method_str + "\": " + (std::string) user.id + "}");
         discpp::Client* client = GetClient();
 		std::unique_ptr<rapidjson::Document> result = client->http_client->SendGetRequest(endpoint, client->http_client->DefaultHeaders(), channel.id, RateLimitBucketType::CHANNEL, body);
 
@@ -192,13 +192,13 @@ namespace discpp {
 	}
 
 	void Message::ClearReactions() {
-		std::string endpoint = Endpoint("/channels/" + std::to_string(channel.id) + "/messages/" + std::to_string(id) + "/reactions");
+		std::string endpoint = Endpoint("/channels/" + (std::string) channel.id + "/messages/" + (std::string) id + "/reactions");
         discpp::Client* client = GetClient();
         client->http_client->SendDeleteRequest(endpoint, client->http_client->DefaultHeaders(), channel.id, RateLimitBucketType::CHANNEL);
 	}
 
 	discpp::Message Message::EditMessage(const std::string& text) {
-		std::string endpoint = Endpoint("/channels/" + std::to_string(channel.id) + "/messages/" + std::to_string(id));
+		std::string endpoint = Endpoint("/channels/" + (std::string) channel.id + "/messages/" + (std::string) id);
         std::string body("{\"content\": \"" + EscapeString(text) + "\"}");
         discpp::Client* client = GetClient();
 		std::unique_ptr<rapidjson::Document> result = client->http_client->SendPatchRequest(endpoint, client->http_client->DefaultHeaders( { { "Content-Type", "application/json" } }), id, RateLimitBucketType::CHANNEL);
@@ -209,7 +209,7 @@ namespace discpp {
 
 	discpp::Message Message::EditMessage(const discpp::EmbedBuilder& embed) {
 
-		std::string endpoint = Endpoint("/channels/" + std::to_string(channel.id) + "/messages/" + std::to_string(id));
+		std::string endpoint = Endpoint("/channels/" + (std::string) channel.id + "/messages/" + (std::string) id);
 		std::unique_ptr<rapidjson::Document> json = embed.ToJson();
         std::string body("{\"embed\": " + DumpJson(*json) + "}");
         discpp::Client* client = GetClient();
@@ -220,7 +220,7 @@ namespace discpp {
 	}
 
 	discpp::Message Message::EditMessage(const int& flags) {
-		std::string endpoint = Endpoint("/channels/" + std::to_string(channel.id) + "/messages/" + std::to_string(id));
+		std::string endpoint = Endpoint("/channels/" + (std::string) channel.id + "/messages/" + (std::string) id);
 		std::string body("{\"flags\": " + std::to_string(flags) + "}");
         discpp::Client* client = GetClient();
         std::unique_ptr<rapidjson::Document> result = client->http_client->SendPatchRequest(endpoint, client->http_client->DefaultHeaders( { { "Content-Type", "application/json" } }), id, RateLimitBucketType::CHANNEL, body);
@@ -230,7 +230,7 @@ namespace discpp {
 	}
 
 	void Message::DeleteMessage() {
-		std::string endpoint = Endpoint("/channels/" + std::to_string(channel.id) + "/messages/" + std::to_string(id));
+		std::string endpoint = Endpoint("/channels/" + (std::string) channel.id + "/messages/" + (std::string) id);
         discpp::Client* client = GetClient();
         client->http_client->SendDeleteRequest(endpoint, client->http_client->DefaultHeaders(), id, RateLimitBucketType::CHANNEL);
 
@@ -239,11 +239,11 @@ namespace discpp {
 
 	inline void Message::PinMessage() {
         discpp::Client* client = GetClient();
-        client->http_client->SendPutRequest(Endpoint("/channels/" + std::to_string(channel.id) + "/pins/" + std::to_string(id)), client->http_client->DefaultHeaders(), id, RateLimitBucketType::CHANNEL);
+        client->http_client->SendPutRequest(Endpoint("/channels/" + (std::string) channel.id + "/pins/" + (std::string) id), client->http_client->DefaultHeaders(), id, RateLimitBucketType::CHANNEL);
 	}
 
 	inline void Message::UnpinMessage() {
         discpp::Client* client = GetClient();
-        client->http_client->SendDeleteRequest(Endpoint("/channels/" + std::to_string(channel.id) + "/pins/" + std::to_string(id)), client->http_client->DefaultHeaders(), id, RateLimitBucketType::CHANNEL);
+        client->http_client->SendDeleteRequest(Endpoint("/channels/" + (std::string) channel.id + "/pins/" + (std::string) id), client->http_client->DefaultHeaders(), id, RateLimitBucketType::CHANNEL);
 	}
 }

--- a/src/user.cpp
+++ b/src/user.cpp
@@ -4,6 +4,7 @@
 #include "member.h"
 #include "cache.h"
 #include "exceptions.h"
+#include "http_client.h"
 
 #include <iomanip>
 #include <sstream>
@@ -63,7 +64,7 @@ namespace discpp {
 	discpp::Channel User::CreateDM() {
 		std::string body("{\"recipient_id\": \"" + std::to_string(id) + "\"}");
         discpp::Client* client = GetClient();
-		std::unique_ptr<rapidjson::Document> result = SendPostRequest(client, Endpoint("/users/@me/channels"), DefaultHeaders(client, { {"Content-Type", "application/json"} }), id, RateLimitBucketType::CHANNEL, body);
+		std::unique_ptr<rapidjson::Document> result = client->http_client->SendPostRequest(Endpoint("/users/@me/channels"), client->http_client->DefaultHeaders( { {"Content-Type", "application/json"} }), id, RateLimitBucketType::CHANNEL, body);
 
 		return discpp::Channel(client, *result);
 	}
@@ -115,8 +116,8 @@ namespace discpp {
         return id.GetFormattedTimestamp();
     }
 
-    std::unordered_map<discpp::Snowflake, std::shared_ptr<discpp::Guild>> User::GetMutualGuilds() {
-         std::unordered_map<discpp::Snowflake, std::shared_ptr<discpp::Guild>> map;
+    std::unordered_map<discpp::Snowflake, std::shared_ptr<discpp::Guild>, discpp::SnowflakeHash> User::GetMutualGuilds() {
+         std::unordered_map<discpp::Snowflake, std::shared_ptr<discpp::Guild>, discpp::SnowflakeHash> map;
 
          discpp::Client* client = GetClient();
 
@@ -161,7 +162,7 @@ namespace discpp {
         if (client->client_user.IsBot()) {
             throw exceptions::ProhibitedEndpointException("users/@me/relationships is a user only endpoint");
         } else {
-            std::unique_ptr<rapidjson::Document> result = SendPutRequest(client, Endpoint("users/@me/relationships/" + std::to_string(this->id)), DefaultHeaders(client), 0, RateLimitBucketType::GLOBAL, "{\"type\":2}");
+            std::unique_ptr<rapidjson::Document> result = client->http_client->SendPutRequest(Endpoint("users/@me/relationships/" + std::to_string(this->id)), client->http_client->DefaultHeaders(), 0, RateLimitBucketType::GLOBAL, "{\"type\":2}");
         }
     }
 
@@ -170,7 +171,7 @@ namespace discpp {
         if(client->client_user.IsBot()) {
             throw exceptions::ProhibitedEndpointException("users/@me/relationships is a user only endpoint");
         } else {
-            std::unique_ptr<rapidjson::Document> result = SendDeleteRequest(client, Endpoint("users/@me/relationships/" + std::to_string(this->id)), DefaultHeaders(client), 0, RateLimitBucketType::GLOBAL);
+            std::unique_ptr<rapidjson::Document> result = client->http_client->SendDeleteRequest(Endpoint("users/@me/relationships/" + std::to_string(this->id)), client->http_client->DefaultHeaders(), 0, RateLimitBucketType::GLOBAL);
         }
 	}
 
@@ -179,7 +180,7 @@ namespace discpp {
         if (!client->client_user.IsBot()) {
             throw exceptions::ProhibitedEndpointException("users/@me/relationships is a user only endpoint");
         } else {
-            std::unique_ptr<rapidjson::Document> result = SendPutRequest(client, Endpoint("users/@me/relationships/" + std::to_string(this->id)), DefaultHeaders(client), 0, RateLimitBucketType::GLOBAL);
+            std::unique_ptr<rapidjson::Document> result = client->http_client->SendPutRequest(Endpoint("users/@me/relationships/" + std::to_string(this->id)), client->http_client->DefaultHeaders(), 0, RateLimitBucketType::GLOBAL);
         }
     }
 
@@ -188,7 +189,7 @@ namespace discpp {
         if(client->client_user.IsBot()) {
             throw exceptions::ProhibitedEndpointException("users/@me/relationships is a user only endpoint");
         } else {
-            std::unique_ptr<rapidjson::Document> result = SendDeleteRequest(client, Endpoint("users/@me/relationships/" + std::to_string(this->id)), DefaultHeaders(client), 0, RateLimitBucketType::GLOBAL);
+            std::unique_ptr<rapidjson::Document> result = client->http_client->SendDeleteRequest(Endpoint("users/@me/relationships/" + std::to_string(this->id)), client->http_client->DefaultHeaders(), 0, RateLimitBucketType::GLOBAL);
         }
     }
 }

--- a/src/user.cpp
+++ b/src/user.cpp
@@ -62,7 +62,7 @@ namespace discpp {
 	}
 
 	discpp::Channel User::CreateDM() {
-		std::string body("{\"recipient_id\": \"" + std::to_string(id) + "\"}");
+		std::string body("{\"recipient_id\": \"" + (std::string) id + "\"}");
         discpp::Client* client = GetClient();
 		std::unique_ptr<rapidjson::Document> result = client->http_client->SendPostRequest(Endpoint("/users/@me/channels"), client->http_client->DefaultHeaders( { {"Content-Type", "application/json"} }), id, RateLimitBucketType::CHANNEL, body);
 
@@ -94,7 +94,7 @@ namespace discpp {
 		} else {
 		    std::string avatar_str = CombineAvatarHash(avatar_hex);
 
-			std::string url = "https://cdn.discordapp.com/avatars/" + std::to_string(id) + "/" + avatar_str;
+			std::string url = "https://cdn.discordapp.com/avatars/" + (std::string) id + "/" + avatar_str;
 			ImageType tmp = img_type;
 			if (tmp == ImageType::AUTO) tmp = is_avatar_gif ? ImageType::GIF : ImageType::PNG;
 			switch (tmp) {
@@ -139,7 +139,7 @@ namespace discpp {
 	}
 
     std::string User::CreateMention() {
-        return "<@" + std::to_string(id) + ">";
+        return "<@" + (std::string) id + ">";
     }
 
     bool User::IsBot() const {
@@ -162,7 +162,7 @@ namespace discpp {
         if (client->client_user.IsBot()) {
             throw exceptions::ProhibitedEndpointException("users/@me/relationships is a user only endpoint");
         } else {
-            std::unique_ptr<rapidjson::Document> result = client->http_client->SendPutRequest(Endpoint("users/@me/relationships/" + std::to_string(this->id)), client->http_client->DefaultHeaders(), 0, RateLimitBucketType::GLOBAL, "{\"type\":2}");
+            std::unique_ptr<rapidjson::Document> result = client->http_client->SendPutRequest(Endpoint("users/@me/relationships/" + (std::string) this->id), client->http_client->DefaultHeaders(), 0, RateLimitBucketType::GLOBAL, "{\"type\":2}");
         }
     }
 
@@ -171,7 +171,7 @@ namespace discpp {
         if(client->client_user.IsBot()) {
             throw exceptions::ProhibitedEndpointException("users/@me/relationships is a user only endpoint");
         } else {
-            std::unique_ptr<rapidjson::Document> result = client->http_client->SendDeleteRequest(Endpoint("users/@me/relationships/" + std::to_string(this->id)), client->http_client->DefaultHeaders(), 0, RateLimitBucketType::GLOBAL);
+            std::unique_ptr<rapidjson::Document> result = client->http_client->SendDeleteRequest(Endpoint("users/@me/relationships/" + (std::string) this->id), client->http_client->DefaultHeaders(), 0, RateLimitBucketType::GLOBAL);
         }
 	}
 
@@ -180,7 +180,7 @@ namespace discpp {
         if (!client->client_user.IsBot()) {
             throw exceptions::ProhibitedEndpointException("users/@me/relationships is a user only endpoint");
         } else {
-            std::unique_ptr<rapidjson::Document> result = client->http_client->SendPutRequest(Endpoint("users/@me/relationships/" + std::to_string(this->id)), client->http_client->DefaultHeaders(), 0, RateLimitBucketType::GLOBAL);
+            std::unique_ptr<rapidjson::Document> result = client->http_client->SendPutRequest(Endpoint("users/@me/relationships/" + (std::string) this->id), client->http_client->DefaultHeaders(), 0, RateLimitBucketType::GLOBAL);
         }
     }
 
@@ -189,7 +189,7 @@ namespace discpp {
         if(client->client_user.IsBot()) {
             throw exceptions::ProhibitedEndpointException("users/@me/relationships is a user only endpoint");
         } else {
-            std::unique_ptr<rapidjson::Document> result = client->http_client->SendDeleteRequest(Endpoint("users/@me/relationships/" + std::to_string(this->id)), client->http_client->DefaultHeaders(), 0, RateLimitBucketType::GLOBAL);
+            std::unique_ptr<rapidjson::Document> result = client->http_client->SendDeleteRequest(Endpoint("users/@me/relationships/" + (std::string) this->id), client->http_client->DefaultHeaders(), 0, RateLimitBucketType::GLOBAL);
         }
     }
 }

--- a/src/webhook.cpp
+++ b/src/webhook.cpp
@@ -109,7 +109,7 @@ namespace discpp {
 
             WaitForRateLimits(nullptr, id, RateLimitBucketType::CHANNEL);
 
-            ix::HttpResponsePtr result = http_client->post(Endpoint("/webhooks/" + std::to_string(id) + "/" + token), body, args);
+            ix::HttpResponsePtr result = http_client->post(Endpoint("/webhooks/" + (std::string) id + "/" + token), body, args);
 
             rapidjson::Document result_json(rapidjson::kObjectType);
             result_json.Parse(result->body);
@@ -117,7 +117,7 @@ namespace discpp {
             return discpp::Message(nullptr, result_json);
         }
 
-        std::unique_ptr<rapidjson::Document> result = http_client->SendPostRequest(Endpoint("/webhooks/" + std::to_string(id) + "/" + token), Headers({ { "Content-Type", "application/json" } }), id, RateLimitBucketType::CHANNEL, DumpJson(message_json));
+        std::unique_ptr<rapidjson::Document> result = http_client->SendPostRequest(Endpoint("/webhooks/" + (std::string) id + "/" + token), Headers({ { "Content-Type", "application/json" } }), id, RateLimitBucketType::CHANNEL, DumpJson(message_json));
 
 		return discpp::Message(nullptr, *result); // @TODO: Make WebhookMessage
 	}
@@ -125,12 +125,12 @@ namespace discpp {
 	void Webhook::EditName(const std::string &name) {
         rapidjson::Document result_json(rapidjson::kObjectType);
         result_json.Parse(R"({"name": ")" + name + "\"}");
-        http_client->SendPatchRequest(discpp::Endpoint("/webhooks/" + std::to_string(id)), Headers({ { "Content-Type", "application/json" } }), id, discpp::RateLimitBucketType::WEBHOOK, DumpJson(result_json));
+        http_client->SendPatchRequest(discpp::Endpoint("/webhooks/" + (std::string) id), Headers({ { "Content-Type", "application/json" } }), id, discpp::RateLimitBucketType::WEBHOOK, DumpJson(result_json));
         this->name = name;
 	}
 
 	void Webhook::Remove() {
-        http_client->SendDeleteRequest(discpp::Endpoint("/webhooks/" + std::to_string(id) + "/" + token), Headers({ { "Content-Type", "application/json" } }), id, discpp::RateLimitBucketType::WEBHOOK);
+        http_client->SendDeleteRequest(discpp::Endpoint("/webhooks/" + (std::string) id + "/" + token), Headers({ { "Content-Type", "application/json" } }), id, discpp::RateLimitBucketType::WEBHOOK);
 	}
 
     std::map<std::string, std::string, discpp::CaseInsensitiveLess> Webhook::Headers(const std::map<std::string, std::string, discpp::CaseInsensitiveLess>& add) {


### PR DESCRIPTION
This allows people to replace the current HTTP library, IXWebsocket, with another one, like cpr for instance.